### PR TITLE
Add an universal save button in the popup menu

### DIFF
--- a/popupMenuButtonItems.js
+++ b/popupMenuButtonItems.js
@@ -98,7 +98,7 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
                 let sessionName = entry.get_text();
                 if (sessionName) {
                     // '  ' is truthy
-                    if (sessionName.trim() === '') {
+                    if (!sessionName.trim()) {
                         sessionName = FileUtils.default_sessionName;
                     }
                 } else {

--- a/popupMenuButtonItems.js
+++ b/popupMenuButtonItems.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const { GObject, St, Clutter } = imports.gi;
+
+const PopupMenu = imports.ui.popupMenu;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+
+const SaveSession = Me.imports.saveSession;
+const IconFinder = Me.imports.iconFinder;
+const FileUtils = Me.imports.utils.fileUtils;
+
+var PopupMenuButtonItems = GObject.registerClass(
+class PopupMenuButtonItems extends GObject.Object {
+
+    _init() {
+        super._init();
+        this.buttonItems = [];
+        this.addButtonItems();
+    }
+
+    addButtonItems() {
+        const popupMenuButtonItemSave = new PopupMenuButtonItemSave('save-symbolic.svg');
+        
+
+        this.buttonItems.push(popupMenuButtonItemSave);
+    }
+
+});
+
+
+var PopupMenuButtonItem = GObject.registerClass(
+class PopupMenuButtonItem extends PopupMenu.PopupMenuItem {
+
+    _init() {
+        super._init('');
+    }
+
+    addButton(iconSymbolic) {
+        let icon = new St.Icon({
+            gicon: IconFinder.find(iconSymbolic),
+            style_class: 'system-status-icon'
+        });
+
+        let button = new St.Button({
+            style_class: 'aws-item-button',
+            can_focus: true,
+            child: icon,
+            x_align: Clutter.ActorAlign.END,
+            x_expand: false,
+            y_expand: true,
+            track_hover: true
+        });
+
+        this.actor.add_child(button);
+
+        return button;
+    }
+
+});
+
+
+var PopupMenuButtonItemSave = GObject.registerClass(
+class PopupMenuButtonItemSave extends PopupMenuButtonItem {
+
+    _init(iconSymbolic) {
+        super._init();
+        this.saveCurrentSessionEntry;
+        this._addButton(iconSymbolic);
+        this._addEntry();
+        // Hide this St.Entry, only shown when user click saveButton.
+        this.saveCurrentSessionEntry.hide();
+
+        this._saveSession = new SaveSession.SaveSession();
+
+    }
+
+    _addButton(iconSymbolic) {
+        const saveButton = super.addButton(iconSymbolic);
+        saveButton.connect('clicked', (button, event) => {
+            this.saveCurrentSessionEntry.show();
+            this.saveCurrentSessionEntry.grab_key_focus();
+        });
+    }
+
+    _addEntry() {
+        this.saveCurrentSessionEntry = new St.Entry({
+            name: 'saveCurrentSession',
+            hint_text: "Type name to save current session, default is defaultSession",
+            track_hover: true,
+            can_focus: true
+        });
+        const clutterText = this.saveCurrentSessionEntry.clutter_text
+        clutterText.connect('key-press-event', (entry, event) => {
+            const symbol = event.get_key_symbol();
+            if (symbol == Clutter.KEY_Return || symbol == Clutter.KEY_KP_Enter || symbol == Clutter.KEY_ISO_Enter) {
+                let sessionName = entry.get_text();
+                if (sessionName) {
+                    if (sessionName.trim() === '') {
+                        sessionName = FileUtils.default_sessionName;
+                    }
+                } else {
+                    sessionName = FileUtils.default_sessionName;
+                }
+
+                this._saveSession.saveSession(sessionName);
+
+                // clear entry
+                entry.set_text('');
+
+                this.saveCurrentSessionEntry.hide();
+            }
+        });
+        this.actor.add_child(this.saveCurrentSessionEntry);
+
+    }
+
+});

--- a/popupMenuButtonItems.js
+++ b/popupMenuButtonItems.js
@@ -97,6 +97,7 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
             if (symbol == Clutter.KEY_Return || symbol == Clutter.KEY_KP_Enter || symbol == Clutter.KEY_ISO_Enter) {
                 let sessionName = entry.get_text();
                 if (sessionName) {
+                    // '  ' is truthy
                     if (sessionName.trim() === '') {
                         sessionName = FileUtils.default_sessionName;
                     }

--- a/saveSession.js
+++ b/saveSession.js
@@ -17,11 +17,11 @@ var SaveSession = class {
         this._defaultAppSystem = Shell.AppSystem.get_default();
     }
 
-    saveSession() {
+    saveSession(sessionName) {
         
         const runningShellApps = this._defaultAppSystem.get_running();
         const sessionConfig = new SessionConfig.SessionConfig();
-        sessionConfig.session_name = FileUtils.default_sessionName;
+        sessionConfig.session_name = sessionName ? sessionName : FileUtils.default_sessionName;
         sessionConfig.session_create_time = new Date().toLocaleString();
         
         for (const runningShellApp of runningShellApps) {

--- a/sessionItemButtons.js
+++ b/sessionItemButtons.js
@@ -97,21 +97,22 @@ class SessionItemButtons extends GObject.Object {
         return button;
     }
 
-    _onClickSave(menuItem, event) {
+    _onClickSave(button, event) {
         this._saveSession.saveSession(this.sessionItem._filename);
     }
     
-    _onClickRestore(menuItem, event) {
+    _onClickRestore(button, event) {
         // Using _restoredApps to hold restored apps so we create new instance every time for now
         const _restoreSession = new RestoreSession.RestoreSession();
         _restoreSession.restoreSession(this.sessionItem._filename);
     }
     
-    _onClickMove(menuItem, event) {
+    _onClickMove(button, event) {
+        log(menuItem);
         this._moveSession.moveWindows(this.sessionItem._filename);
     }
 
-    _onClickClose(menuItem, event) {
+    _onClickClose(button, event) {
         // TODO Close specified windows in the session?
         this._closeSession.closeWindows();
     }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,3 +1,9 @@
+.confirm-before-operate {
+    color: #F00; 
+    font-weight: bold; 
+    font-style: italic
+}
+
 .aws-item-separator {
     border-radius: 32px;
     padding: 4px;


### PR DESCRIPTION
Add an universal save button in the popup menu, so we can save the current session as a specified name or leave it empty to save as the default name.