### PR TITLE
Fix: #6: Too many logs in journalctl: Can't update stage views actor

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -39,11 +39,6 @@ class AwsIndicator extends PanelMenu.Button {
             style_class: 'popup-menu-icon'
         });
         this.add_child(icon);
-        this.buttonText = new St.Label({
-            text: _("Loading..."),
-            y_align: Clutter.ActorAlign.CENTER
-        });
-        this.add_child(this.buttonText);
 
         this._createMenu();
 


### PR DESCRIPTION
Fix: #6: Too many logs in journalctl: Can't update stage views actor

Not sure the exactly reason :(, any way this label is useless, should be removed. The session files can't be too many, they can be loaded into menu quickly.  