### PR TITLE
Add icon description and improve logic when save windows

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -123,13 +123,14 @@ class AwsIndicator extends PanelMenu.Button {
                 log(`${file.get_path()} (file type is ${file_type}) is not a regular file, skipping`);
                 return;
             }
-
             const content_type = info.get_content_type();
             if (content_type !== 'text/plain') {
                 // Debug
                 log(`${file.get_path()} (content type is ${content_type}) is not a text file, skipping`);
                 return;
             }
+
+            
             let parent = file.get_parent();
             let parentPath;
             // https://gjs-docs.gnome.org/gio20~2.66p/gio.file#method-get_parent

--- a/indicator.js
+++ b/indicator.js
@@ -115,25 +115,38 @@ class AwsIndicator extends PanelMenu.Button {
 
         let sessionFileInfos = [];
         FileUtils.listAllSessions(null, false, (file, info) => {
-            if (info.get_file_type() === Gio.FileType.REGULAR) {
-                let parent = file.get_parent();
-                let parentPath;
-                // https://gjs-docs.gnome.org/gio20~2.66p/gio.file#method-get_parent
-                // If the this represents the root directory of the file system, then null will be returned.
-                if (parent === null) {
-                    // Impossible, who puts sessions under the /?
-                    parentPath = '/';
-                } else {
-                    parentPath = parent.get_path();
-                }
-                // Debug
-                log(`Processing ${file.get_path()} under ${parentPath}`);
-                sessionFileInfos.push({
-                    info: info,
-                    file: file
-                });
+            // We have an interest in regular and text files
 
+            const file_type = info.get_file_type();
+            if (file_type !== Gio.FileType.REGULAR) {
+                // Debug
+                log(`${file.get_path()} (file type is ${file_type}) is not a regular file, skipping`);
+                return;
             }
+
+            const content_type = info.get_content_type();
+            if (content_type !== 'text/plain') {
+                // Debug
+                log(`${file.get_path()} (content type is ${content_type}) is not a text file, skipping`);
+                return;
+            }
+            let parent = file.get_parent();
+            let parentPath;
+            // https://gjs-docs.gnome.org/gio20~2.66p/gio.file#method-get_parent
+            // If the this represents the root directory of the file system, then null will be returned.
+            if (parent === null) {
+                // Impossible, who puts sessions under the /?
+                parentPath = '/';
+            } else {
+                parentPath = parent.get_path();
+            }
+            // Debug
+            log(`Processing ${file.get_path()} under ${parentPath}`);
+            sessionFileInfos.push({
+                info: info,
+                file: file
+            });
+
         });
 
         // Sort by modification time: https://gjs-docs.gnome.org/gio20~2.66p/gio.fileenumerator

--- a/saveSession.js
+++ b/saveSession.js
@@ -135,7 +135,7 @@ var SaveSession = class {
             );
 
             if (success) {
-                log(`Open windows session saved as '${sessionConfig.session_name}' located in '${sessions_path}'!`);
+                log(`Saved open windows as a session in ${session_file_path}!`);
             }
             return success;
         }

--- a/ui/popupMenuButtonItems.js
+++ b/ui/popupMenuButtonItems.js
@@ -94,6 +94,14 @@ class PopupMenuButtonItem extends PopupMenu.PopupMenuItem {
         return timeline;
     }
 
+    // Add the icon description. Only once icon may be too weird?
+    addIconDescription(iconDescription) {
+        this.iconDescriptionLabel = new St.Label({
+            text: iconDescription
+        });
+        this.actor.add_child(this.iconDescriptionLabel);
+    }
+
 });
 
 
@@ -109,6 +117,7 @@ class PopupMenuButtonItemClose extends PopupMenuButtonItem {
         this.closeSession = new CloseSession.CloseSession();
 
         this._createButton(iconSymbolic);
+        this.addIconDescription('Close windows');
         this._addConfirm();
         this._addYesAndNoButtons();
         this._addClosingPrompt();
@@ -220,6 +229,7 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
         super._init();
         this.saveCurrentSessionEntry;
         this._createButton(iconSymbolic);
+        this.addIconDescription('Save windows');
         this._addEntry();
         // Hide this St.Entry, only shown when user click saveButton.
         this.saveCurrentSessionEntry.hide();

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -42,7 +42,8 @@ function listAllSessions(sessionPath, recursion, callback) {
         fileEnumerator = sessionPathFile.enumerate_children(
             [Gio.FILE_ATTRIBUTE_STANDARD_NAME, 
                 Gio.FILE_ATTRIBUTE_STANDARD_TYPE, 
-                Gio.FILE_ATTRIBUTE_TIME_MODIFIED].join(','),
+                Gio.FILE_ATTRIBUTE_TIME_MODIFIED,
+                Gio.FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE].join(','),
             Gio.FileQueryInfoFlags.NONE,
             null);
     } catch(e) {

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -86,6 +86,15 @@ function trashSession(sessionName) {
     }
 }
 
+function isDirectory(sessionName) {
+    const sessionFilePath = GLib.build_filenamev([sessions_path, sessionName]);
+    if (GLib.file_test(sessionFilePath, GLib.FileTest.IS_DIR)) {
+        return true;
+    }
+
+    return false;
+}
+
 // test
 // let index = 0;
 // listAllSessions(null, false, (file, info) => {


### PR DESCRIPTION
1. Add the icon description. Only once icon may be too weird?
2. Skip non-text files as well when load session files to panel menu
3. Check whether a file associate with the sessionName is a directory or not, if it's a directory show a ERROR prompt to user.