### PR TITLE
Fix an issue in tooltip.js: Remove the timeout of tooltip_browse_id in destroy()

### DIFF
--- a/utils/tooltip.js
+++ b/utils/tooltip.js
@@ -20,9 +20,6 @@ const Main = imports.ui.main;
  * Adapted from: https://github.com/RaphaelRochet/applications-overview-tooltip
  * See also: https://github.com/GNOME/gtk/blob/master/gtk/gtktooltip.c
  */
-var TOOLTIP_BROWSE_ID = 0;
-var TOOLTIP_BROWSE_MODE = false;
-
 var Tooltip = class Tooltip {
 
     constructor(params) {
@@ -31,6 +28,9 @@ var Tooltip = class Tooltip {
         this._bin = null;
         this._hoverTimeoutId = 0;
         this._showing = false;
+
+        this._tooltip_browse_id = 0;
+        this._tooltip_browse_mode = false;
 
         this._destroyId = this.parent.connect(
             'destroy',
@@ -217,11 +217,11 @@ var Tooltip = class Tooltip {
         }
 
         // Enable browse mode
-        TOOLTIP_BROWSE_MODE = true;
+        this._tooltip_browse_mode = true;
 
-        if (TOOLTIP_BROWSE_ID) {
-            GLib.source_remove(TOOLTIP_BROWSE_ID);
-            TOOLTIP_BROWSE_ID = 0;
+        if (this._tooltip_browse_id) {
+            GLib.source_remove(this._tooltip_browse_id);
+            this._tooltip_browse_id = 0;
         }
 
         if (this._hoverTimeoutId) {
@@ -248,9 +248,9 @@ var Tooltip = class Tooltip {
             });
         }
 
-        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
-            TOOLTIP_BROWSE_MODE = false;
-            TOOLTIP_BROWSE_ID = 0;
+        this._tooltip_browse_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+            this._tooltip_browse_mode = false;
+            this._tooltip_browse_id = 0;
             return false;
         });
 
@@ -271,7 +271,7 @@ var Tooltip = class Tooltip {
                 } else {
                     this._hoverTimeoutId = GLib.timeout_add(
                         GLib.PRIORITY_DEFAULT,
-                        (TOOLTIP_BROWSE_MODE) ? 60 : 500,
+                        (this._tooltip_browse_mode) ? 60 : 500,
                         () => {
                             this._show();
                             this._hoverTimeoutId = 0;
@@ -296,6 +296,11 @@ var Tooltip = class Tooltip {
         if (this._bin) {
             Main.layoutManager.uiGroup.remove_actor(this._bin);
             this._bin.destroy();
+        }
+
+        if (this._tooltip_browse_id) {
+            GLib.source_remove(this._tooltip_browse_id);
+            this._tooltip_browse_id = 0;
         }
 
         if (this._hoverTimeoutId) {


### PR DESCRIPTION
Fix an issue in tooltip.js: Remove the timeout of tooltip_browse_id in destroy()

Try to fix https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1227 and also meet the review guidelines :)