### PR TITLE
Restore windows geometry and move them to their own workspace based on `Meta.Display::window-created` signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ After confirm to save:
 2. Restore saved open windows and move windows automatically in the progress
 3. Move windows according to a saved session
 4. Restore window state, including `Always on Top` and `Always on Visible Workspace`
-5. ...
+5. Restore window size and position
+6. ...
 
 # Panel menu items
 
@@ -61,6 +62,13 @@ After confirm to save:
 # Dependencies
 This project uses `ps` to get some information from a process, install it via `dnf install procps-ng` if don't have.
 
+# Known issues
+
+1. On both X11 and Wayland, if click restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) continually during the process of restoring, the window size and position may can't be restored, and it may restore many instances of an application. **As a workaround, click restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) only once util all apps restored.**
+2. On Wayland, if [a window is maximized along the left or right sides of the screen](https://help.gnome.org/users/gnome-help/stable/shell-windows-maximize.html.en) before closed, its size and position can't be restored. **As a workaround, click move button (<img src=icons/move-symbolic.svg width="14" height="14">) to restore their size and position.**
+3. On both X11 and Wayland, due to [this bug](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2134) within mutter, in Overview, if click restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) then immediately click the newly created workspace, the Gnome Shell can crash. To fix this issue, the Overview will be toggled hidden after click the restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) when in Overview. I will remove this behaviour once I find a better solution or it's fixed in a new version of Gnome Shell.
+4. ...
+
 # Where are the saved sessions?
 They are all in `~/.config/another-window-session-manager/sessions`. When use an exsiting name to save the current open windows, the previous file will be copied to `~/.config/another-window-session-manager/sessions/backups` as a new name, which is the-old-session-name**.backup-current-timestamp**.
 
@@ -70,7 +78,7 @@ They are all in `~/.config/another-window-session-manager/sessions`. When use an
 3. - Restore saved open windows
       - [x] Restore saved open windows
       - [x] Move to belonging workspace automatically
-      - [ ] Restore window's geometry
+      - [x] Restore window size and position
 4. - Saved open windows list
       - [x] Saved open windows list
       - [x] Restore button

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ After confirm to save:
 This project uses `ps` to get some information from a process, install it via `dnf install procps-ng` if don't have.
 
 # Where are the saved sessions?
-They are all in `~/.config/another-window-session-manager/sessions`. When use an exsiting name to save the current open windows, the previous file will be copied to `~/.config/another-window-session-manager/sessions/backups` as a new name, which is {the-old-session-name}**.backup-{timestampt}**.
+They are all in `~/.config/another-window-session-manager/sessions`. When use an exsiting name to save the current open windows, the previous file will be copied to `~/.config/another-window-session-manager/sessions/backups` as a new name, which is the-old-session-name**.backup-current-timestamp**.
 
 # TODO
 1. - Save open windows

--- a/closeSession.js
+++ b/closeSession.js
@@ -19,6 +19,13 @@ var CloseSession = class {
 
     closeWindows() {
         this._log.debug('Closing open windows');
+        
+        let workspaceManager = global.workspace_manager;
+        for (let i = 0; i < workspaceManager.n_workspaces; i++) {
+            // Make workspaces non-persistent, so they can be removed if no windows in it
+            workspaceManager.get_workspace_by_index(i)._keepAliveId = false;
+        }
+
         let running_apps = this._defaultAppSystem.get_running();
         for (const app of running_apps) {
             const app_name = app.get_name();

--- a/indicator.js
+++ b/indicator.js
@@ -89,7 +89,14 @@ class AwsIndicator extends PanelMenu.Button {
     
             // On X11, we have to create enough workspace and move windows before receive the first-frame signal.
             // If not, all windows will be shown in current workspace when stay in Overview, which is not pretty.
-            this._moveSession.createEnoughWorkspaceAndMoveWindows(metaWindow, saved_window_sessions);
+            let matchedSavedWindowSession = this._moveSession.createEnoughWorkspaceAndMoveWindows(metaWindow, saved_window_sessions);
+            
+            if (matchedSavedWindowSession) {
+                // Fix window geometry later on in first-frame or shown signal
+                // TODO The side-effect is when a window is already in the current workspace there will be two same logs (The window 'Clocks' is already on workspace 0 for Clocks) in the journalctl, which is not pretty. 
+                // TODO Maybe it's better to use another state to indicator whether a window has been restored geometry.
+                matchedSavedWindowSession.moved = false;
+            }
         }
         
         let metaWindowActor = metaWindow.get_compositor_private();

--- a/indicator.js
+++ b/indicator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { GObject, St, Gio, GLib, Clutter } = imports.gi;
+const { GObject, St, Gio, GLib, Clutter, Shell } = imports.gi;
 
 const Mainloop = imports.mainloop;
 
@@ -9,6 +9,8 @@ const Me = ExtensionUtils.getCurrentExtension();
 
 const PopupMenu = imports.ui.popupMenu;
 const PanelMenu = imports.ui.panelMenu;
+
+const MoveSession = Me.imports.moveSession;
 
 const FileUtils = Me.imports.utils.fileUtils;
 const SessionItem = Me.imports.ui.sessionItem;
@@ -24,6 +26,8 @@ class AwsIndicator extends PanelMenu.Button {
 
     _init() {
         super._init(0.0, "Another Window Session Manager");
+
+        this._windowTracker = Shell.WindowTracker.get_default();
 
         this._prefsUtils = new PrefsUtils.PrefsUtils();
         this._log = new Log.Log();
@@ -59,6 +63,46 @@ class AwsIndicator extends PanelMenu.Button {
         // See: PopupMenu#itemActivated() => this.menu._getTopMenu().close
         this.menu.itemActivated = function(animate) {};
 
+        // Set a initial value to prevent error in `journalctl` when starting gnome-shell
+        this._restoringApps = new Map();
+        this._moveSession = new MoveSession.MoveSession();
+
+        // this._connectIds = [];
+        this._display = global.display;
+        this._displayId = this._display.connect('window-created', this._windowCreated.bind(this));
+        
+    }
+
+    _windowCreated(display, metaWindow, userData) {
+        let metaWindowActor = metaWindow.get_compositor_private();
+        // https://github.com/paperwm/PaperWM/blob/10215f57e8b34a044e10b7407cac8fac4b93bbbc/tiling.js#L2120
+        // https://gjs-docs.gnome.org/meta8~8_api/meta.windowactor#signal-first-frame
+        let firstFrameId = metaWindowActor.connect('first-frame', () => {
+            const shellApp = this._windowTracker.get_window_app(metaWindow);
+            if (!shellApp) {
+                return;
+            }
+
+            if (this._log.isDebug()) {
+                // NOTE: The title of a dialog (for example a close warning dialog, like gnome-terminal) attached to a window is ''
+                this._log.debug(`window-created -> first-frame: ${shellApp.get_name()} -> ${metaWindow.get_title()}`);
+            }
+
+            const shellAppData = this._restoringApps.get(shellApp);
+            if (!shellAppData) {
+                return;
+            }
+    
+            const saved_window_sessions = shellAppData.saved_window_sessions;
+            this._moveSession.moveWindowsByMetaWindow(metaWindow, saved_window_sessions);
+        
+            metaWindowActor.disconnect(firstFrameId);
+            firstFrameId = 0;
+        });
+
+        // TODO disconnect? Comment it due to too many errors when disable extension.
+        // this._connectIds.push([metaWindowActor, firstFrameId]);
+        
     }
 
     _onOpenStateChanged(menu, state) {
@@ -179,7 +223,7 @@ class AwsIndicator extends PanelMenu.Button {
         for (const sessionFileInfo of sessionFileInfos) {
             const info = sessionFileInfo.info;
             const file = sessionFileInfo.file;
-            let item = new SessionItem.SessionItem(info, file);
+            let item = new SessionItem.SessionItem(info, file, this);
             this._sessionsMenuSection.addMenuItem(item, this._itemIndex++);
         }
         
@@ -252,6 +296,20 @@ class AwsIndicator extends PanelMenu.Button {
         if (this._log) {
             this._log.destroy();
             this._log = null;
+        }
+
+        // if (this._connectIds) {
+        //     for (let [obj, id] of this._connectIds) {
+        //         if (id) {
+        //             obj.disconnect(id);
+        //         }
+        //     }
+        //     this._connectIds = null;
+        // }
+        
+        if (this._displayId) {
+            this._display.disconnect(this._displayId);
+            this._displayId = 0;
         }
 
         this.destroy();

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 4
+    "version": 5
   }

--- a/model/sessionConfig.js
+++ b/model/sessionConfig.js
@@ -48,5 +48,32 @@ var SessionConfig = class {
     backup_time; // str
     restore_times; // list = []
     x_session_config_objects = []; // list[SessionConfigObject]
-    
+
+
+    /**
+     * Sort session_config_objects by desktop number
+     * 
+     */
+    sort() {
+        let x_session_config_objects_copy = this.x_session_config_objects.slice();
+        x_session_config_objects_copy.sort((o1, o2) => {
+            const desktop_number1 = o1.desktop_number;
+            const desktop_number2 = o2.desktop_number;
+
+            const diff = desktop_number1 - desktop_number2;
+            if (diff === 0) {
+                return 0;
+            }
+
+            if (diff > 0) {
+                return 1;
+            }
+
+            if (diff < 0) {
+                return -1;
+            }
+
+        });
+        return x_session_config_objects_copy;
+    }
 }

--- a/model/sessionConfig.js
+++ b/model/sessionConfig.js
@@ -5,6 +5,15 @@ class WindowState {
     is_sticky; // bool
     // If always on top
     is_above; // bool
+
+    // Additional fields
+
+    // https://gjs-docs.gnome.org/meta9~9_api/meta.window#method-get_maximized
+    // 0: Not in the maximization mode
+    // 1: Horizontal - Meta.MaximizeFlags.HORIZONTAL
+    // 2: Vertical - Meta.MaximizeFlags.VERTICAL
+    // 3. Both - Meta.MaximizeFlags.BOTH
+    meta_maximized;
 }
 
 class WindowPosition {  

--- a/moveSession.js
+++ b/moveSession.js
@@ -165,40 +165,6 @@ var MoveSession = class {
 
     }
 
-    _restoreWindowStateAndGeometryOnWayland(open_window, saved_window_session, cbFunc) {
-        GLib.idle_add(GLib.PRIORITY_LOW + 1, () => {
-            let frameRect = open_window.get_frame_rect();
-            let current_x = frameRect.x;
-            let current_y = frameRect.y;
-            let current_width = frameRect.width;
-            let current_height = frameRect.height;
-            // if x, y width and height all 0, the window probably still not be full rendered, recheck
-            if (current_x === 0 &&
-                current_y === 0 &&
-                current_width === 0 &&
-                current_height === 0) 
-            {
-                return GLib.SOURCE_CONTINUE;
-            }
-
-            // In `journalctl /usr/bin/gnome-shell` still has the below error, looks harmless, ignore it:
-            // meta_window_set_stack_position_no_sync: assertion 'window->stack_position >= 0' failed
-            this._restoreWindowGeometry(open_window, saved_window_session);
-
-            // The window can't be moved due to previous reason, change workspace if necessary.
-            const desktop_number = saved_window_session.desktop_number;
-            const current_workspace = open_window.get_workspace();
-            if (desktop_number !== current_workspace.index()) {
-                open_window.change_workspace_by_index(desktop_number, false);
-            }
-
-            if (cbFunc) {
-                cbFunc();
-            }
-            return GLib.SOURCE_REMOVE;
-        });
-    }
-
     _restoreWindowGeometry(metaWindow, saved_window_session) {
         const window_position = saved_window_session.window_position;
         if (window_position.provider === 'Meta') {

--- a/moveSession.js
+++ b/moveSession.js
@@ -95,7 +95,7 @@ var MoveSession = class {
         this._createEnoughWorkspace(desktop_number);
         if (this._log.isDebug()) {
             const shellApp = this._windowTracker.get_window_app(metaWindow);
-            this._log.debug(`Moving ${shellApp?.get_name()} - ${metaWindow.get_title()} to ${desktop_number}`);
+            this._log.debug(`CEWM: Moving ${shellApp?.get_name()} - ${metaWindow.get_title()} to ${desktop_number}`);
         }
         metaWindow.change_workspace_by_index(desktop_number, false);
     }
@@ -114,7 +114,7 @@ var MoveSession = class {
             this._createEnoughWorkspace(desktop_number);
             if (this._log.isDebug()) {
                 const shellApp = this._windowTracker.get_window_app(metaWindow);
-                this._log.debug(`Moving ${shellApp?.get_name()} - ${metaWindow.get_title()} to ${desktop_number}`);
+                this._log.debug(`MWMW: Moving ${shellApp?.get_name()} - ${metaWindow.get_title()} to ${desktop_number}`);
             }
             metaWindow.change_workspace_by_index(desktop_number, false);
 

--- a/moveSession.js
+++ b/moveSession.js
@@ -17,6 +17,8 @@ var MoveSession = class {
         this.sessionName = FileUtils.default_sessionName;
         this._defaultAppSystem = Shell.AppSystem.get_default();
 
+        this._connectIds = [];
+
     }
 
     moveWindows(sessionName) {
@@ -101,6 +103,7 @@ var MoveSession = class {
                         metaWindowActor.disconnect(firstFrameId);
                     });
                 });
+                this._connectIds.push([metaWindowActor, firstFrameId]);
             }
             
             this._restoreWindowStateAndGeometryOnWayland(open_window, saved_window_session, null);
@@ -231,6 +234,13 @@ var MoveSession = class {
         if (this._log) {
             this._log.destroy();
             this._log = null;
+        }
+
+        if (this._connectIds) {
+            this._connectIds.forEach((obj, id) => {
+                obj.disconnect(id);
+            });
+            this._connectIds = null;
         }
 
     }

--- a/moveSession.js
+++ b/moveSession.js
@@ -92,9 +92,10 @@ var MoveSession = class {
         }
 
         if (Meta.is_wayland_compositor()) {
-            let metaWindowActor = open_window.get_compositor_private();
             // It makes no sense to connect the 'first-frame' if a window has existed already
             if (first) {
+                let metaWindowActor = open_window.get_compositor_private();
+                // See: https://github.com/paperwm/PaperWM/blob/10215f57e8b34a044e10b7407cac8fac4b93bbbc/tiling.js#L2120
                 const firstFrameId = metaWindowActor.connect('first-frame', () => {
                     this._restoreWindowStateAndGeometryOnWayland(open_window, saved_window_session, () => {
                         metaWindowActor.disconnect(firstFrameId);

--- a/moveSession.js
+++ b/moveSession.js
@@ -94,7 +94,7 @@ var MoveSession = class {
                     const current_y = frameRect.y;
                     const current_width = frameRect.width;
                     const current_height = frameRect.height;
-                    // x, y width and height
+                    // if x, y width and height all 0, the window probably still not be full rendered, recheck
                     if (current_x === 0 &&
                         current_y === 0 &&
                         current_width === 0 &&
@@ -102,7 +102,16 @@ var MoveSession = class {
                         return GLib.SOURCE_CONTINUE;
                     }
 
+                    // In `journalctl /usr/bin/gnome-shell` still has the below error, looks harmless, ignore it:
+                    // meta_window_set_stack_position_no_sync: assertion 'window->stack_position >= 0' failed
                     this._restoreWindowGeometry(open_window, saved_window_session);
+
+                    // The window can't be moved due to previous reason, change workspace if necessary.
+                    const desktop_number = saved_window_session.desktop_number;
+                    const current_workspace = open_window.get_workspace();
+                    if (desktop_number !== current_workspace.index()) {
+                        open_window.change_workspace_by_index(desktop_number, false);
+                    }
                     actor.disconnect(signal)
                     return GLib.SOURCE_REMOVE;
                 });

--- a/restoreSession.js
+++ b/restoreSession.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Shell, Gio, GLib, Meta } = imports.gi;
+const { Shell, Gio, GLib } = imports.gi;
 const Util = imports.misc.util;
 
 const { ByteArray } = imports.byteArray;

--- a/restoreSession.js
+++ b/restoreSession.js
@@ -143,7 +143,7 @@ var RestoreSession = class {
         // log(`windows-changed triggered for ${shellApp.get_name()}`);
         const shellAppData = this._restoredApps.get(shellApp);
         let saved_window_sessions = shellAppData.saved_window_sessions
-        this._moveSession.moveWindowsByShellApp(shellApp, saved_window_sessions);
+        this._moveSession.moveWindowsByShellApp(shellApp, saved_window_sessions, true);
     }
 
     _appIsRunning(app) {

--- a/restoreSession.js
+++ b/restoreSession.js
@@ -146,6 +146,8 @@ var RestoreSession = class {
 
         if (this._appIsRunning(shellApp)) {
             this._log.debug(`${shellApp.get_name()} is running, skipping`)
+            // Delete shellApp from this._restoringApps to prevent it move the same app when close and open it manually.
+            this._restoringApps.delete(shellApp);
             return [true, true];
         }
 

--- a/restoreSession.js
+++ b/restoreSession.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Shell, Gio, GLib } = imports.gi;
+const { Shell, Gio, GLib, Meta } = imports.gi;
 const Util = imports.misc.util;
 
 const { ByteArray } = imports.byteArray;
@@ -21,8 +21,19 @@ var RestoreSession = class {
 
         this.sessionName = FileUtils.default_sessionName;
         this._defaultAppSystem = Shell.AppSystem.get_default();
+        this._windowTracker = Shell.WindowTracker.get_default();        
+
+        // All launching apps info by Shell.App#launch()
+        this._restoringApps = new Map();
+
+        // All launched apps info by Shell.App#launch()
         this._restoredApps = new Map();
         this._moveSession = new MoveSession.MoveSession();
+
+        this._display = global.display;
+        this._displayId = null;
+
+        this._connectIds = [];
     }
 
     restoreSession(sessionName) {
@@ -56,6 +67,8 @@ var RestoreSession = class {
                 logError(new Error(`Session details not found: ${session_file_path}`));
                 return;
             }
+            
+            this._displayId = global.display.connect('window-created', this._windowCreated.bind(this));
 
             for (const session_config_object of session_config_objects) {
                 const app_name = session_config_object.app_name;
@@ -66,6 +79,15 @@ var RestoreSession = class {
                     if (desktop_file_id) {
                         const shell_app = this._defaultAppSystem.lookup_app(desktop_file_id)
                         if (shell_app) {
+                            const restoringShellAppData = this._restoringApps.get(shell_app);
+                            if (restoringShellAppData) {
+                                restoringShellAppData.saved_window_sessions.push(session_config_object);
+                            } else {
+                                this._restoringApps.set(shell_app, {
+                                    saved_window_sessions: [session_config_object]
+                                });
+                            }
+                            
                             [launched, running] = this.launch(shell_app);
                             if (launched) {
                                 if (!running) {
@@ -75,10 +97,7 @@ var RestoreSession = class {
                                 if (existingShellAppData) {
                                     existingShellAppData.saved_window_sessions.push(session_config_object);
                                 } else {
-                                    // TODO Better to listen Meta.Workspace::window-added(Meta.Window), so we can also know a window added by running the command line in the case of there is no desktop_file_id at all?
-                                    const windows_change_id = shell_app.connect('windows-changed', this._autoMoveWindows.bind(this));
                                     this._restoredApps.set(shell_app, {
-                                        windows_change_id: windows_change_id,
                                         saved_window_sessions: [session_config_object]
                                     });
                                 }
@@ -130,20 +149,43 @@ var RestoreSession = class {
             return [true, true];
         }
 
+        // -1 current workspace?
+        let workspace = -1;
         const launched = shellApp.launch(
             // 0 for current event timestamp
             0, 
-            -1,
+            workspace,
             this._getProperGpuPref(shellApp));
         return [launched, false];
     }
 
-    _autoMoveWindows(shellApp) {
-        // Debug
-        // log(`windows-changed triggered for ${shellApp.get_name()}`);
-        const shellAppData = this._restoredApps.get(shellApp);
-        let saved_window_sessions = shellAppData.saved_window_sessions
-        this._moveSession.moveWindowsByShellApp(shellApp, saved_window_sessions, true);
+    _windowCreated(display, metaWindow, userData) {
+        let metaWindowActor = metaWindow.get_compositor_private();
+        // https://github.com/paperwm/PaperWM/blob/10215f57e8b34a044e10b7407cac8fac4b93bbbc/tiling.js#L2120
+        // https://gjs-docs.gnome.org/meta8~8_api/meta.windowactor#signal-first-frame
+        const firstFrameId = metaWindowActor.connect('first-frame', () => {
+            const shellApp = this._windowTracker.get_window_app(metaWindow);
+            if (!shellApp) {
+                return;
+            }
+
+            if (this._log.isDebug()) {
+                // NOTE: The title of a dialog (for example a close warning dialog, like gnome-terminal) attached to a window is ''
+                this._log.debug(`window-created -> first-frame: ${shellApp.get_name()} -> ${metaWindow.get_title()}`);
+            }
+
+            const shellAppData = this._restoringApps.get(shellApp);
+            if (!shellAppData) {
+                return;
+            }
+    
+            const saved_window_sessions = shellAppData.saved_window_sessions;
+            this._moveSession.moveWindowsByMetaWindow(metaWindow, saved_window_sessions);
+        
+        });
+        
+        this._connectIds.push([metaWindowActor, firstFrameId]);
+        
     }
 
     _appIsRunning(app) {
@@ -174,15 +216,26 @@ var RestoreSession = class {
 
     destroy() {
         if (this._restoredApps) {
-            for (const [app, v] of this._restoredApps) {
-                app.disconnect(v.windows_change_id);
-            }
             this._restoredApps.clear();
             this._restoredApps = null;
         }
 
+        if (this._restoringApps) {
+            this._restoringApps.clear();
+            this._restoringApps = null;
+        }
+
+        if (this._displayId) {
+            this._display.disconnect(this._displayId);
+            this._displayId = 0;
+        }
+
         if (this._defaultAppSystem) {
             this._defaultAppSystem = null;
+        }
+
+        if (this._windowTracker) {
+            this._windowTracker = null;
         }
 
         if (this._moveSession) {
@@ -192,6 +245,13 @@ var RestoreSession = class {
         if (this._log) {
             this._log.destroy();
             this._log = null;
+        }
+
+        if (this._connectIds) {
+            for (let [obj, id] of this._connectIds) {
+                obj.disconnect(id);
+            }
+            this._connectIds = null;
         }
         
     }

--- a/saveSession.js
+++ b/saveSession.js
@@ -98,6 +98,7 @@ var SaveSession = class {
 
         // Save open windows
         try {
+            sessionConfig.x_session_config_objects = sessionConfig.sort();
             const success = this.save2File(sessionConfig);
             if (success) {
                 // TODO saved Notification

--- a/saveSession.js
+++ b/saveSession.js
@@ -86,6 +86,7 @@ var SaveSession = class {
                     // See: ui/windowMenu.js:L80
                     window_state.is_sticky = metaWindow.is_on_all_workspaces();
                     window_state.is_above = metaWindow.is_above();
+                    window_state.meta_maximized = metaWindow.get_maximized();
 
                     sessionConfig.x_session_config_objects.push(sessionConfigObject);    
                     

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -57,7 +57,12 @@
 .aws-item-separator {
     border-radius: 32px;
     padding: 4px;
-    border: 1px solid #282c2c;
+    /* 
+    Remove cycle / border in the background in case everyone think this separator is a clickable button, actually it's just a view-only separator.
+
+    https://developer.mozilla.org/en-US/docs/Web/CSS/border 
+    */
+    border: none;
 }
 
 .aws-item-separator > StIcon {

--- a/ui/sessionItem.js
+++ b/ui/sessionItem.js
@@ -12,10 +12,11 @@ const SessionItemButtons = Me.imports.ui.sessionItemButtons;
 var SessionItem = GObject.registerClass(
 class SessionItem extends PopupMenu.PopupMenuItem {
     
-    _init(fileInfo, file) {
+    _init(fileInfo, file, indicator) {
         // Initialize this component, so we can use this.label etc
         super._init("");
 
+        this._indicator = indicator;
         this._filename = fileInfo.get_name();
         this._filepath = file.get_path();
         this._modification_time = 'Unknown';

--- a/ui/sessionItemButtons.js
+++ b/ui/sessionItemButtons.js
@@ -109,7 +109,6 @@ class SessionItemButtons extends GObject.Object {
             style_class: 'system-status-icon'
         });
 
-        // TODO Remove cycle in the background in case everyone think this separator is a clickable button, actually it's just a view-only separator.
         let button = new St.Button({
             style_class: 'aws-item-separator',
             can_focus: false,

--- a/ui/sessionItemButtons.js
+++ b/ui/sessionItemButtons.js
@@ -141,6 +141,7 @@ class SessionItemButtons extends GObject.Object {
         const _restoreSession = new RestoreSession.RestoreSession(this);
         _restoreSession.restoreSession(this.sessionItem._filename);
 
+        // TODO Add to Settings or add an if in the future version when confirm the below bug is fixed.
         // Leave Overview if we are in Overview to reduce or fix `Bug in window manager: Workspace does not exist to index!` in mutter
         // See: https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2134
         if (Main.overview.visible) {

--- a/ui/sessionItemButtons.js
+++ b/ui/sessionItemButtons.js
@@ -2,6 +2,8 @@
 
 const { GObject, St, Clutter } = imports.gi;
 
+const Main = imports.ui.main;
+
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
@@ -138,6 +140,12 @@ class SessionItemButtons extends GObject.Object {
         // Using _restoredApps to hold restored apps so we create new instance every time for now
         const _restoreSession = new RestoreSession.RestoreSession(this);
         _restoreSession.restoreSession(this.sessionItem._filename);
+
+        // Leave Overview if we are in Overview to reduce or fix `Bug in window manager: Workspace does not exist to index!` in mutter
+        // See: https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2134
+        if (Main.overview.visible) {
+            Main.overview.toggle();
+        }
     }
     
     _onClickMove(button, event) {

--- a/ui/sessionItemButtons.js
+++ b/ui/sessionItemButtons.js
@@ -134,8 +134,9 @@ class SessionItemButtons extends GObject.Object {
     }
     
     _onClickRestore(button, event) {
+        this.sessionItem._indicator._restoringApps = [];
         // Using _restoredApps to hold restored apps so we create new instance every time for now
-        const _restoreSession = new RestoreSession.RestoreSession();
+        const _restoreSession = new RestoreSession.RestoreSession(this);
         _restoreSession.restoreSession(this.sessionItem._filename);
     }
     

--- a/utils/log.js
+++ b/utils/log.js
@@ -13,8 +13,12 @@ var Log = class {
         
     }
 
+    isDebug() {
+        return this._prefsUtils.isDebug();
+    }
+
     debug(logContent) {
-        if (this._prefsUtils.isDebug()) {
+        if (this.isDebug()) {
             log(`[DEBUG][Another window session manager] ${logContent}`);
         }
     }

--- a/utils/log.js
+++ b/utils/log.js
@@ -23,6 +23,10 @@ var Log = class {
         }
     }
 
+    error(e, logContent) {
+        logError(e, `[ERROR][Another window session manager] ${logContent}`);
+    }
+
     destroy() {
         if (this._prefsUtils) {
             this._prefsUtils.destroy();


### PR DESCRIPTION
- [x] Support X11
- [x] Support Wayland

-----
1. Restore window size and position on X11 and Wayland
2. Save open windows in order of workspace index
3. Remove the separator button's border to make it a real separator
