### PR TITLE
Code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # gnome-shell-extension-another-window-session-manager
-Close and save open windows. And restore saved windows sessions.
+Close and save open windows. And restore from a saved windows session.
 
-Most importantly, it supports both X.org and Wayland!
+Most importantly, it supports both X11 and Wayland!
 
-This project is in early development, but it's basically working now. I'm planing to add some other features.
+This project is in early development, but it's basically working now. More features will be added in the future.
 
 This extension is based on [St(Shell Toolkit)](https://gjs-docs.gnome.org/st10~1.0_api/) and [Shell](https://gjs-docs.gnome.org/shell01~0.1_api/) APIs.
 
@@ -67,7 +67,8 @@ This project uses `ps` to get some information from a process, install it via `d
 1. On both X11 and Wayland, if click restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) continually during the process of restoring, the window size and position may can't be restored, and it may restore many instances of an application. **As a workaround, click restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) only once util all apps restored.**
 2. On Wayland, if [a window is maximized along the left or right sides of the screen](https://help.gnome.org/users/gnome-help/stable/shell-windows-maximize.html.en) before closed, its size and position can't be restored. **As a workaround, click move button (<img src=icons/move-symbolic.svg width="14" height="14">) to restore their size and position.**
 3. On both X11 and Wayland, due to [this bug](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/2134) within mutter, in Overview, if click restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) then immediately click the newly created workspace, the Gnome Shell can crash. To fix this issue, the Overview will be toggled hidden after click the restore button (<img src=icons/restore-symbolic.svg width="14" height="14">) when in Overview. I will remove this behaviour once I find a better solution or it's fixed in a new version of Gnome Shell.
-4. ...
+4. If an application lunched via a command line, it can't be moved to its own workspace, can't be restored both size and position. **Please click the app icon to launch an application before save it in the session and restore**.
+5. ...
 
 # Where are the saved sessions?
 They are all in `~/.config/another-window-session-manager/sessions`. When use an exsiting name to save the current open windows, the previous file will be copied to `~/.config/another-window-session-manager/sessions/backups` as a new name, which is the-old-session-name**.backup-current-timestamp**.

--- a/extension.js
+++ b/extension.js
@@ -17,7 +17,7 @@ function enable() {
 
 function disable() {
     if (_indicator) {
-        _indicator._onDestroy();
+        _indicator.destroy();
         _indicator = null;
     }
     

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 5
+    "version": 6
   }

--- a/moveSession.js
+++ b/moveSession.js
@@ -34,7 +34,7 @@ var MoveSession = class {
             return;
         }
 
-        this._log.debug(`Moving windows by saved session located in ${session_file_path}`);
+        this._log.info(`Moving windows by saved session located in ${session_file_path}`);
         const session_file = Gio.File.new_for_path(session_file_path);
         let [success, contents] = session_file.load_contents(null);
         if (success) {
@@ -67,7 +67,7 @@ var MoveSession = class {
             const title = open_window.get_title();
             const desktop_number = saved_window_session.desktop_number;
 
-            this._log.debug(`Auto move the window '${title}' to workspace ${desktop_number} for ${shellApp.get_name()}`);
+            this._log.debug(`Auto move the window '${title}' to workspace ${desktop_number} from ${open_window.get_workspace().index()} for ${shellApp.get_name()}`);
             
             try {                
                 this._restoreWindowStateAndGeometry(open_window, saved_window_session);

--- a/restoreSession.js
+++ b/restoreSession.js
@@ -50,7 +50,7 @@ var RestoreSession = class {
             return;
         }
 
-        this._log.debug(`Restoring saved session from ${session_file_path}`);
+        this._log.info(`Restoring saved session from ${session_file_path}`);
         try {
             this.restoreSessionFromPath(session_file_path);
         } catch (e) {

--- a/saveSession.js
+++ b/saveSession.js
@@ -158,7 +158,7 @@ var SaveSession = class {
             );
 
             if (success) {
-                this._log.debug(`Saved open windows as a session in ${session_file_path}!`);
+                this._log.info(`Saved open windows as a session in ${session_file_path}!`);
             }
             return success;
         }

--- a/utils/log.js
+++ b/utils/log.js
@@ -27,7 +27,7 @@ var Log = class {
         logError(e, `[ERROR][Another window session manager] ${logContent}`);
     }
 
-    info() {
+    info(logContent) {
         log(`[INFO][Another window session manager] ${logContent}`);
     }
 

--- a/utils/signal.js
+++ b/utils/signal.js
@@ -1,0 +1,31 @@
+const { GObject } = imports.gi;
+
+var Signal = class {
+
+    constructor() {
+
+    }
+
+    /**
+     * Disconnect signal from an object without the below error / warning in `journalctl`:
+     * 
+     * ../gobject/gsignal.c:2732: instance '0x55629xxxxxx' has no handler with id '11000'
+     */
+    disconnectSafely(obj, signalId) {
+        if (!signalId) {
+            return;
+        }
+
+        // https://gjs-docs.gnome.org/gobject20~2.66p/gobject.signal_handler_find
+        // Fix ../gobject/gsignal.c:2732: instance '0x55629xxxxxx' has no handler with id '11000' in some case, see two callers for more info 
+        const matchedId = GObject.signal_handler_find(
+            obj, // GObject.Object
+            GObject.SignalMatchType.ID, 
+            signalId,
+            null, null, null, null);
+        if (matchedId) {
+            obj.disconnect(signalId);
+        }
+    }
+
+}


### PR DESCRIPTION
1. Remove source in destroy()
2. Disconnect signals in indicator to prevent errors or warnings when disable this extension
3. Update known issues
4. Change some logs level to info, so we know important information without enable debugging mode