### PR TITLE
Session names cannot contains the forward slash (/)

### DIFF
--- a/saveSession.js
+++ b/saveSession.js
@@ -180,6 +180,7 @@ var SaveSession = class {
         } catch (e) {
             logError(e, `Failed to write session to disk`);
             global.notify_error(`Failed to write session to disk`, e.message);
+            throw e;
         }
 
         return false;


### PR DESCRIPTION
1. Session names cannot contains the forward slash (/)
2. Display the raw error message when failed to save the windows session to the disk

Fixes: https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager/issues/29