### PR TITLE
Change the "Are you sure to close open windows?" to "Confirm?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ This extension is based on several [Gnome technologies](https://www.gnome.org/te
 ## Close open windows
 Click item to close open windows:
 
-![image](https://user-images.githubusercontent.com/2271720/147727060-c5b64c45-7b00-4343-a28d-28d88003be87.png)
+![image](https://user-images.githubusercontent.com/2271720/163229388-5504c439-ae4a-445b-a3f7-aa768af3975d.png)
 
 
 After confirm to close:
 
-![image](https://user-images.githubusercontent.com/2271720/147727104-436ea99b-3539-4eae-b1c4-a3fa83f8734d.png)
+![image](https://user-images.githubusercontent.com/2271720/163229434-2c06b9d2-2b19-4205-80e8-58c2ae68a0cd.png)
 
 ## Save open windows
 Click item to save open windows as a session:
@@ -37,7 +37,7 @@ Click item to save open windows as a session:
 
 After confirm to save:
 
-![image](https://user-images.githubusercontent.com/2271720/147727180-633fa9e0-4b66-4763-8cf1-f365ef77f7b3.png)
+![image](https://user-images.githubusercontent.com/2271720/163229511-f83df883-5afe-47ae-8855-fef68586e5a4.png)
 
 ## Activate the current session to be restored at startup
 ![image](https://user-images.githubusercontent.com/2271720/162792703-20da002b-b590-4df5-964e-9c586e8915bc.png)

--- a/ui/popupMenuButtonItems.js
+++ b/ui/popupMenuButtonItems.js
@@ -165,7 +165,7 @@ class PopupMenuButtonItemClose extends PopupMenuButtonItem {
         this.closingLabel = new St.Label({
             style_class: 'confirm-before-operate',
             text: 'Closing open windows ...',
-            x_expand: true,
+            x_expand: false,
             x_align: Clutter.ActorAlign.CENTER,
         });
         this.actor.add_child(this.closingLabel);
@@ -189,8 +189,8 @@ class PopupMenuButtonItemClose extends PopupMenuButtonItem {
     _addConfirm() {
         this.confirmLabel = new St.Label({
             style_class: 'confirm-before-operate',
-            text: 'Are you sure to close open windows?',
-            x_expand: true,
+            text: 'Confirm?',
+            x_expand: false,
             x_align: Clutter.ActorAlign.START,
         });
         this.actor.add_child(this.confirmLabel);
@@ -263,7 +263,7 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
     _addSavingPrompt() {
         this.savingLabel = new St.Label({
             style_class: 'confirm-before-operate',
-            x_expand: true,
+            x_expand: false,
             x_align: Clutter.ActorAlign.CENTER,
         });
         this.actor.add_child(this.savingLabel);


### PR DESCRIPTION
Change the "Are you sure to close open windows?" to "Confirm?" and make prompts align left, hope this change can be friendly to the big screen. 

Related issue: #23

![image](https://user-images.githubusercontent.com/2271720/163229388-5504c439-ae4a-445b-a3f7-aa768af3975d.png)

![image](https://user-images.githubusercontent.com/2271720/163229434-2c06b9d2-2b19-4205-80e8-58c2ae68a0cd.png)

![image](https://user-images.githubusercontent.com/2271720/163229511-f83df883-5afe-47ae-8855-fef68586e5a4.png)
