### PR TITLE
Create EndSessionDialog dbus proxy and connect dbus signals asynchron…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -13,6 +13,7 @@ const Autostart = Me.imports.ui.autostart;
 
 let _indicator;
 let _autostartServiceProvider;
+let _openWindowsInfoTracker;
 
 function enable() {
     _indicator = new Indicator.AwsIndicator();
@@ -20,7 +21,7 @@ function enable() {
 
     _autostartServiceProvider = new Autostart.AutostartServiceProvider();
     
-    new OpenWindowsInfoTracker.OpenWindowsInfoTracker();
+    _openWindowsInfoTracker = new OpenWindowsInfoTracker.OpenWindowsInfoTracker();
     
 }
 
@@ -33,6 +34,11 @@ function disable() {
     if (_autostartServiceProvider) {
         _autostartServiceProvider.disable();
         _autostartServiceProvider = null;
+    }
+
+    if (_openWindowsInfoTracker) {
+        _openWindowsInfoTracker.destroy();
+        _openWindowsInfoTracker = null;
     }
     
 }

--- a/metadata.json
+++ b/metadata.json
@@ -9,5 +9,5 @@
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 19
+    "version": 20
   }

--- a/ui/autostart.js
+++ b/ui/autostart.js
@@ -69,7 +69,7 @@ var AutostartServiceProvider = GObject.registerClass(
             this._log.debug(`DBus name ${name} acquired!`);
         }
     
-        onNameLost(_connection, name) {
+        onNameLost(connection, name) {
             this._log.debug(`Dbus name ${name} lost`);
         }
 


### PR DESCRIPTION
Create EndSessionDialog dbus proxy and connect dbus signals asynchronously, otherwise gnome freezes for some time (about 25 seconds in my machine, maybe it is timeout of connecting dbus signals) when logging in, unlocking the screen or disable/enable it. 

Fixes https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager/issues/47.