### PR TITLE
Port to Gnome 45

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,18 +115,19 @@ sudo chmod 644 /etc/udev/rules.d/60-awsm-ydotool-uinput.rules
 
 # 3. Copy ydotool.service to /usr/lib/systemd/user, so `systemctl --user enable ydotool.service` can work
 sudo cp /usr/lib/systemd/system/ydotool.service /usr/lib/systemd/user
-# 4. Start the ydotoold service under the normal user
+# 4. Start ydotool.service at startup automatically for the current normal user
+systemctl --user enable ydotool.service
+# 5. Note that you may have to restart the system if the following commands are not working
+# 6. Start the ydotoold service for the current normal user
 systemctl --user start ydotool.service
-# 5. Check if ydotoold service is working. The word `hello` should print on the terminal, if not you might need to reboot the system or try to relogin your account. 
+# 7. Check if ydotoold service is working. The word `hello` should print on the terminal, if not you might need to reboot the system or try to relogin your account. 
 ydotool type 'hello'
 
 ## misc. ##
 
-# Check if the ydotoold service is running, if not it can be started by the folowing cmd
+# Check if the ydotoold service is running, if not you may have to restart the system or start ydotool.service
 systemctl --user status ydotool.service
 
-# Check if ydotool is working. the word `hello` should print on the terminal, if not you might need to reboot the system or try to relogin your account. 
-ydotool type 'hello'
 ```
 
 Note that it's no necessary to run `systemctl --user enable ydotool.service`, because this extension starts `ydotool.service` every time while you use it to close windows.

--- a/closeSession.js
+++ b/closeSession.js
@@ -1,31 +1,30 @@
 'use strict';
 
-const { Meta, Shell, Gio, GLib } = imports.gi;
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Shell from 'gi://Shell';
+import Meta from 'gi://Meta';
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-const Util = imports.misc.util;
+import * as Log from './utils/log.js';
+import * as PrefsUtils from './utils/prefsUtils.js';
+import * as SubprocessUtils from './utils/subprocessUtils.js';
+import * as DateUtils from './utils/dateUtils.js';
+import * as Function from './utils/function.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const Log = Me.imports.utils.log;
-const PrefsUtils = Me.imports.utils.prefsUtils;
-const SubprocessUtils = Me.imports.utils.subprocessUtils;
-const DateUtils = Me.imports.utils.dateUtils;
-const Function = Me.imports.utils.function;
+import * as Constants from './constants.js';
 
-const Constants = Me.imports.constants;
+import * as UiHelper from './ui/uiHelper.js';
 
-const UiHelper = Me.imports.ui.uiHelper;
-
-var flags = {
+export const flags = {
     closeWindows: 1 << 0,
     logoff:       1 << 1,
 };
 
-var allFlags = flags.closeWindows | flags.logoff;
+const allFlags = flags.closeWindows | flags.logoff;
 
-var CloseSession = class {
+export const CloseSession = class {
     constructor(flags) {
         this._log = new Log.Log();
         this._prefsUtils = new PrefsUtils.PrefsUtils();

--- a/extension.js
+++ b/extension.js
@@ -15,6 +15,7 @@ import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/ex
 import * as string from './utils/string.js';
 
 import * as Log from './utils/log.js';
+import * as FileUtils from './utils/fileUtils.js';
 
 
 let _indicator;
@@ -34,6 +35,8 @@ export default class AnotherWindowSessionManagerExtension extends Extension {
         
         this._settings.connect('changed::show-indicator', () => this.showOrHideIndicator());
         this.showOrHideIndicator();
+
+        FileUtils.init(this);
     
         _autostartServiceProvider = new Autostart.AutostartServiceProvider();
         

--- a/extension.js
+++ b/extension.js
@@ -23,7 +23,7 @@ let _openWindowsTracker;
 let _autoclose;
 let _windowPickerServiceProvider;
 
-export default class AnotherWindowSessionManager extends Extension {
+export default class AnotherWindowSessionManagerExtension extends Extension {
 
     constructor(metadata) {
         super(metadata);

--- a/extension.js
+++ b/extension.js
@@ -1,100 +1,97 @@
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-const Main = imports.ui.main;
+import * as OpenWindowsTracker from './openWindowsTracker.js';
 
-const OpenWindowsTracker = Me.imports.openWindowsTracker;
+import * as Indicator from './indicator.js';
+import * as Autostart from './ui/autostart.js';
+import * as Autoclose from './ui/autoclose.js';
+import {WindowTilingSupport} from './windowTilingSupport.js';
+import * as WindowPicker from './utils/WindowPicker.js';
 
-const Indicator = Me.imports.indicator;
-const Autostart = Me.imports.ui.autostart;
-const Autoclose = Me.imports.ui.autoclose;
-const WindowTilingSupport = Me.imports.windowTilingSupport.WindowTilingSupport;
-const WindowPicker = Me.imports.utils.WindowPicker;
-const PrefsUtils = Me.imports.utils.prefsUtils;
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
+import * as string from './utils/string.js';
 
-Me.imports.utils.string;
+import * as Log from './utils/log.js';
 
-const Log = Me.imports.utils.log;
 
 let _indicator;
 let _autostartServiceProvider;
 let _openWindowsTracker;
 let _autoclose;
 let _windowPickerServiceProvider;
-let _settingUtils;
 
-function enable() {
-    _settingUtils = new PrefsUtils.PrefsUtils();
+export default class AnotherWindowSessionManager extends Extension {
 
-    _settingUtils.getSettings().connect('changed::show-indicator', () => showOrHideIndicator());
-    showOrHideIndicator();
+    constructor(metadata) {
+        super(metadata);
+        this._settings = this.getSettings('org.gnome.shell.extensions.another-window-session-manager');
+    }
 
-    _autostartServiceProvider = new Autostart.AutostartServiceProvider();
+    enable() {
+        
+        this._settings.connect('changed::show-indicator', () => this.showOrHideIndicator());
+        this.showOrHideIndicator();
     
-    WindowTilingSupport.initialize();
-
-    _openWindowsTracker = new OpenWindowsTracker.OpenWindowsTracker();
-    _autoclose = new Autoclose.Autoclose();
-
-    _windowPickerServiceProvider = new WindowPicker.WindowPickerServiceProvider();
-    _windowPickerServiceProvider.enable();
-}
-
-function showOrHideIndicator() {
-    if (_settingUtils.getSettings().get_boolean('show-indicator')) {
-        if (!_indicator) {
-            _indicator = new Indicator.AwsIndicator();
-            Main.panel.addToStatusArea('Another Window Session Manager', _indicator);
+        _autostartServiceProvider = new Autostart.AutostartServiceProvider();
+        
+        WindowTilingSupport.initialize();
+    
+        _openWindowsTracker = new OpenWindowsTracker.OpenWindowsTracker();
+        _autoclose = new Autoclose.Autoclose();
+    
+        _windowPickerServiceProvider = new WindowPicker.WindowPickerServiceProvider();
+        _windowPickerServiceProvider.enable();
+    }
+    
+    showOrHideIndicator() {
+        if (this._settings.get_boolean('show-indicator')) {
+            if (!_indicator) {
+                _indicator = new Indicator.AwsIndicator();
+                Main.panel.addToStatusArea('Another Window Session Manager', _indicator);
+            }
+        } else {
+            this.hideIndicator();
         }
-    } else {
-        hideIndicator();
     }
-}
-
-function hideIndicator() {
-    if (_indicator) {
-        _indicator.destroy();
-        _indicator = null;
-    }
-}
-
-function disable() {
-    if (_settingUtils) {
-        _settingUtils.destroy();
-        _settingUtils = null;
-    }
-
-    hideIndicator();
-
-    if (_autostartServiceProvider) {
-        _autostartServiceProvider.disable();
-        _autostartServiceProvider = null;
-    }
-
-    if (_openWindowsTracker) {
-        _openWindowsTracker.destroy();
-        _openWindowsTracker = null;
-    }
-
-    WindowTilingSupport.destroy();
     
-    if (_autoclose) {
-        _autoclose.destroy();
-        _autoclose = null;
+    hideIndicator() {
+        if (_indicator) {
+            _indicator.destroy();
+            _indicator = null;
+        }
     }
-
-    Log.Log.destroyDefault();
-
-    if (_windowPickerServiceProvider) {
-        _windowPickerServiceProvider.destroy();
-        _windowPickerServiceProvider = null;
+    
+    disable() {
+    
+        this.hideIndicator();
+    
+        if (_autostartServiceProvider) {
+            _autostartServiceProvider.disable();
+            _autostartServiceProvider = null;
+        }
+    
+        if (_openWindowsTracker) {
+            _openWindowsTracker.destroy();
+            _openWindowsTracker = null;
+        }
+    
+        WindowTilingSupport.destroy();
+        
+        if (_autoclose) {
+            _autoclose.destroy();
+            _autoclose = null;
+        }
+    
+        Log.Log.destroyDefault();
+    
+        if (_windowPickerServiceProvider) {
+            _windowPickerServiceProvider.destroy();
+            _windowPickerServiceProvider = null;
+        }
+    
     }
-
-}
-
-function init() {
-
+    
 }

--- a/indicator.js
+++ b/indicator.js
@@ -1,27 +1,33 @@
 'use strict';
 
-const { GObject, St, Gio, GLib, Clutter, Shell, Meta } = imports.gi;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Clutter from 'gi://Clutter';
+import Shell from 'gi://Shell';
+import Meta from 'gi://Meta';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const PopupMenu = imports.ui.popupMenu;
-const PanelMenu = imports.ui.panelMenu;
-
-const MoveSession = Me.imports.moveSession;
-const RestoreSession = Me.imports.restoreSession;
-
-const FileUtils = Me.imports.utils.fileUtils;
-const SessionItem = Me.imports.ui.sessionItem;
-const SearchSessionItem = Me.imports.ui.searchSessionItem;
-const PopupMenuButtonItems = Me.imports.ui.popupMenuButtonItems;
-const IconFinder = Me.imports.utils.iconFinder;
-const PrefsUtils = Me.imports.utils.prefsUtils;
-const Log = Me.imports.utils.log;
-const Signal = Me.imports.utils.signal;
+import * as ExtensionUtils from 'resource:///org/gnome/shell/misc/extensionUtils.js';
 
 
-var AwsIndicator = GObject.registerClass(
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+
+import * as MoveSession from './moveSession.js';
+import * as RestoreSession from './restoreSession.js';
+
+import * as FileUtils from './utils/fileUtils.js';
+import * as SessionItem from './ui/sessionItem.js';
+import * as SearchSessionItem from './ui/searchSessionItem.js';
+import * as PopupMenuButtonItems from './ui/popupMenuButtonItems.js';
+import * as IconFinder from './utils/iconFinder.js';
+import * as PrefsUtils from './utils/prefsUtils.js';
+import * as Log from './utils/log.js';
+import * as Signal from './utils/signal.js';
+
+
+export const AwsIndicator = GObject.registerClass(
 class AwsIndicator extends PanelMenu.Button {
 
     _init() {
@@ -32,8 +38,8 @@ class AwsIndicator extends PanelMenu.Button {
         this._prefsUtils = new PrefsUtils.PrefsUtils();
         this._settings = this._prefsUtils.getSettings();
         this._log = new Log.Log();
-
         this._signal = new Signal.Signal();
+        this._fileUtils = new FileUtils.FileUtils();
         
         this._itemIndex = 0;
 
@@ -319,7 +325,7 @@ class AwsIndicator extends PanelMenu.Button {
         this._log.debug('List all sessions to add session items');
         
         let sessionFileInfos = [];
-        await FileUtils.listAllSessions(null, false, (file, info) => {
+        await this._fileUtils.listAllSessions(null, false, (file, info) => {
             // We have an interest in regular and text files
 
             const file_type = info.get_file_type();

--- a/indicator.js
+++ b/indicator.js
@@ -39,7 +39,6 @@ class AwsIndicator extends PanelMenu.Button {
         this._settings = this._prefsUtils.getSettings();
         this._log = new Log.Log();
         this._signal = new Signal.Signal();
-        this._fileUtils = new FileUtils.FileUtils();
         
         this._itemIndex = 0;
 
@@ -325,7 +324,7 @@ class AwsIndicator extends PanelMenu.Button {
         this._log.debug('List all sessions to add session items');
         
         let sessionFileInfos = [];
-        await this._fileUtils.listAllSessions(null, false, (file, info) => {
+        await FileUtils.listAllSessions(null, false, (file, info) => {
             // We have an interest in regular and text files
 
             const file_type = info.get_file_type();

--- a/indicator.js
+++ b/indicator.js
@@ -100,9 +100,9 @@ class AwsIndicator extends PanelMenu.Button {
             // Install https://extensions.gnome.org/extension/4679/burn-my-windows/ to watch this process.
 
             const shellApp = this._windowTracker.get_window_app(metaWindow);
-            let shellAppData = RestoreSession.restoringApps.get(shellApp);
+            let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
             if (!shellAppData) {
-                shellAppData = RestoreSession.restoringApps.get(metaWindow.get_pid());
+                shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
             }
 
             if (shellAppData) {
@@ -150,9 +150,9 @@ class AwsIndicator extends PanelMenu.Button {
             // NOTE: The title of a dialog (for example a close warning dialog, like gnome-terminal) attached to a window is ''
             this._log.debug(`window-created -> first-frame: ${shellApp.get_name()} -> ${metaWindow.get_title()}`);
 
-            let shellAppData = RestoreSession.restoringApps.get(shellApp);
+            let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
             if (!shellAppData) {
-                shellAppData = RestoreSession.restoringApps.get(metaWindow.get_pid());
+                shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
             }
             if (!shellAppData) {
                 return;
@@ -184,9 +184,9 @@ class AwsIndicator extends PanelMenu.Button {
             // NOTE: The title of a dialog (for example a close warning dialog, like gnome-terminal) attached to a window is ''
             this._log.debug(`window-created -> shown: ${shellApp.get_name()} -> ${metaWindow.get_title()}`);
 
-            let shellAppData = RestoreSession.restoringApps.get(shellApp);
+            let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
             if (!shellAppData) {
-                shellAppData = RestoreSession.restoringApps.get(metaWindow.get_pid());
+                shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
             }
             if (!shellAppData) {
                 return;
@@ -237,9 +237,9 @@ class AwsIndicator extends PanelMenu.Button {
             // NOTE: The title of a dialog (for example a close warning dialog, like gnome-terminal) attached to a window is ''
             this._log.debug(`window-created -> title changed: ${shellApp.get_name()} -> ${metaWindow.get_title()}`);
 
-            let shellAppData = RestoreSession.restoringApps.get(shellApp);
+            let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
             if (!shellAppData) {
-                shellAppData = RestoreSession.restoringApps.get(metaWindow.get_pid());
+                shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
             }
             if (!shellAppData) {
                 return;

--- a/metadata.json
+++ b/metadata.json
@@ -3,13 +3,9 @@
     "description": "Close open windows gracefully and save them as a session. And you can restore them when necessary manually or automatically at startup. Most importantly, it supports both X11 and Wayland!\n\nMain features:\n- Restore the previous session at startup. disabled by default.\n- Save running apps and windows automatically when necessary, this will be used to restore the previous session at startup.\n- Close running apps and windows automatically before Log Out, Restart, Power Off. disabled by default.\n- Close running windows gracefully\n- Close apps with multiple windows gracefully via ydotool so you don't lose sessions of this app (See also: How to make Close by rules work)\n- Save running apps and windows manually\n- Restore a selected session at startup (See also: #9). disabled by default.\n- Restore a saved session manually\n- Restore window state, including Always on Top, Always on Visible Workspace and maximization\n- Restore window workspace, size and position\n- Restore 2 column window tiling\n- Stash all supported window states so that those states will be restored after gnome shell restarts via Alt+F2 -> r or killall -3 gnome-shell.\n- Move windows to their own workspace according to a saved session\n- Support multi-monitor\n- Remove saved session to trash\n- Search saved session by the session name fuzzily\n\nFor more information, please visit https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager/blob/feature-close-save-session-while-logout/README.md.\n\nPlease report issues on Github.",
     "name": "Another Window Session Manager",
     "shell-version": [
-      "40",
-      "41",
-      "42",
-      "43",
-      "44"
+      "45"
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 41
+    "version": 42
   }

--- a/model/closeWindowsRule.js
+++ b/model/closeWindowsRule.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const { GObject } = imports.gi;
+import GObject from 'gi://GObject';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const CloseWindowsRule = Me.imports.model.closeWindowsRule;
+import * as CloseWindowsRule from './closeWindowsRule.js';
 
-var CloseWindowsWhitelist = GObject.registerClass({
+
+export const CloseWindowsWhitelist = GObject.registerClass({
 }, class CloseWindowsWhitelist extends GObject.Object {
     id; // int. just like the id in MySQL. Used to update or delete rows.
     name; // string. Can be any string
@@ -21,7 +20,7 @@ var CloseWindowsWhitelist = GObject.registerClass({
     }
 });
 
-var CloseWindowsRuleBase = class {
+export const CloseWindowsRuleBase = class {
     category; // string. Applications, Keywords
     type; // string, rule type, such as 'shortcut'
     value; // GdkShortcuts, order and the rule pairs, such as "{1: 'Ctrl+Q}'".
@@ -31,7 +30,7 @@ var CloseWindowsRuleBase = class {
     keyDelay; // int, for example: `enabydotool key --key-delay 500 29:1 16:1 16:0 29:0`
 } 
 
-var CloseWindowsRuleByKeyword = class extends CloseWindowsRuleBase {
+export const CloseWindowsRuleByKeyword = class extends CloseWindowsRuleBase {
     id; // int. just like the id in MySQL. Used to update or delete rows.
     keyword; // string. Can be any string
     compareWith; // string. title, wm_class, wm_class_instance, app_name...
@@ -43,7 +42,7 @@ var CloseWindowsRuleByKeyword = class extends CloseWindowsRuleBase {
     }
 }
 
-var CloseWindowsRuleByApp = class extends CloseWindowsRuleBase {
+export const CloseWindowsRuleByApp = class extends CloseWindowsRuleBase {
     appId; // string, such as 'firefox.desktop'
     appDesktopFilePath; // string, such as '/usr/share/applications/firefox.desktop'
     appName; // string, such as 'Firefox'
@@ -57,7 +56,7 @@ var CloseWindowsRuleByApp = class extends CloseWindowsRuleBase {
 * See: https://gitlab.gnome.org/GNOME/gtk/blob/d726ecdb5d1ece870585c7be89eb6355b2482544/gdk/gdkenums.h:L73
 * See: https://gitlab.gnome.org/GNOME/gtk/blob/1ce79b29e363e585872901424d3b72041b55e3e4/gtk/gtkeventcontrollerkey.c:L203
 */
-var GdkShortcuts = GObject.registerClass({
+export const GdkShortcuts = GObject.registerClass({
 }, class GdkShortcuts extends GObject.Object{
     /**
      * For example: Ctrl+Q

--- a/model/sessionConfig.js
+++ b/model/sessionConfig.js
@@ -37,7 +37,7 @@ class WindowTiling {
     window_tile_for = new WindowTilingFor(); // WindowTilingFor
 }
 
-var SessionConfigObject = class {
+export const SessionConfigObject = class {
 
     window_id; // str, hexadecimal on X11, int on Wayland
     desktop_number; // int
@@ -82,7 +82,7 @@ var SessionConfigObject = class {
     compositor_type; // string. X11, Wayland
 }
 
-var SessionConfig = class {
+export const SessionConfig = class {
     session_name; // str
     session_create_time; // str
     backup_time; // str

--- a/moveSession.js
+++ b/moveSession.js
@@ -24,7 +24,6 @@ export const MoveSession = class {
         this.sessionName = FileUtils.default_sessionName;
         this._defaultAppSystem = Shell.AppSystem.get_default();
         this._windowTracker = Shell.WindowTracker.get_default();
-        this._fileUtils = new FileUtils.FileUtils();
 
         this._sourceIds = [];
 
@@ -37,7 +36,7 @@ export const MoveSession = class {
             sessionName = this.sessionName;
         }
 
-        const sessions_path = this._fileUtils.get_sessions_path();
+        const sessions_path = FileUtils.get_sessions_path();
         const session_file_path = GLib.build_filenamev([sessions_path, sessionName]);
         if (!GLib.file_test(session_file_path, GLib.FileTest.EXISTS)) {
             logError(new Error(`Session file not found: ${session_file_path}`));
@@ -48,7 +47,7 @@ export const MoveSession = class {
         const session_file = Gio.File.new_for_path(session_file_path);
         let [success, contents] = session_file.load_contents(null);
         if (success) {
-            let session_config = this._fileUtils.getJsonObj(contents);
+            let session_config = FileUtils.getJsonObj(contents);
 
             const session_config_objects = session_config.x_session_config_objects;
             if (!session_config_objects) {

--- a/moveSession.js
+++ b/moveSession.js
@@ -1,21 +1,22 @@
 'use strict';
 
-const { Shell, Gio, GLib, Meta } = imports.gi;
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Shell from 'gi://Shell';
+import Meta from 'gi://Meta';
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as UiHelper from './ui/uiHelper.js';
 
-const UiHelper = Me.imports.ui.uiHelper;
+import * as FileUtils from './utils/fileUtils.js';
+import * as Log from './utils/log.js';
+import * as DateUtils from './utils/dateUtils.js';
 
-const FileUtils = Me.imports.utils.fileUtils;
-const Log = Me.imports.utils.log;
-const DateUtils = Me.imports.utils.dateUtils;
+import {WindowTilingSupport} from './windowTilingSupport.js';
 
-const WindowTilingSupport = Me.imports.windowTilingSupport.WindowTilingSupport;
 
-var MoveSession = class {
+export const MoveSession = class {
 
     constructor() {
         this._log = new Log.Log();
@@ -23,6 +24,7 @@ var MoveSession = class {
         this.sessionName = FileUtils.default_sessionName;
         this._defaultAppSystem = Shell.AppSystem.get_default();
         this._windowTracker = Shell.WindowTracker.get_default();
+        this._fileUtils = new FileUtils.FileUtils();
 
         this._sourceIds = [];
 
@@ -35,7 +37,7 @@ var MoveSession = class {
             sessionName = this.sessionName;
         }
 
-        const sessions_path = FileUtils.get_sessions_path();
+        const sessions_path = this._fileUtils.get_sessions_path();
         const session_file_path = GLib.build_filenamev([sessions_path, sessionName]);
         if (!GLib.file_test(session_file_path, GLib.FileTest.EXISTS)) {
             logError(new Error(`Session file not found: ${session_file_path}`));
@@ -46,7 +48,7 @@ var MoveSession = class {
         const session_file = Gio.File.new_for_path(session_file_path);
         let [success, contents] = session_file.load_contents(null);
         if (success) {
-            let session_config = FileUtils.getJsonObj(contents);
+            let session_config = this._fileUtils.getJsonObj(contents);
 
             const session_config_objects = session_config.x_session_config_objects;
             if (!session_config_objects) {

--- a/openWindowsTracker.js
+++ b/openWindowsTracker.js
@@ -77,7 +77,6 @@ export const OpenWindowsTracker = class {
         this._log = new Log.Log();
         this._prefsUtils = new PrefsUtils.PrefsUtils();
         this._settings = this._prefsUtils.getSettings();
-        this._fileUtils = new FileUtils.FileUtils();
 
         this._saveSession = new SaveSession.SaveSession();
         this._moveSession = new MoveSession.MoveSession();
@@ -287,7 +286,7 @@ export const OpenWindowsTracker = class {
             return;
         }
 
-        const sessionContent = this._fileUtils.getJsonObj(contents);
+        const sessionContent = FileUtils.getJsonObj(contents);
         Log.Log.getDefault().debug(`Prepare to restore window session from ${sessionFilePath}`);
 
         this._allSavedWindowSessions.push(sessionContent);
@@ -408,7 +407,7 @@ export const OpenWindowsTracker = class {
 
         this._log.debug(`${window.get_title()}(${app?.get_name()}) was closed. Cleaning up its saved session files.`);
 
-        this._fileUtils.removeFile(sessionFilePath);
+        FileUtils.removeFile(sessionFilePath);
         this._removeOrphanSessionConfigs(app, sessionDirectory);
     }
 
@@ -426,11 +425,11 @@ export const OpenWindowsTracker = class {
                 sessionNames.add(`${MetaWindowUtils.getStableWindowId(metaWindow)}.json`);
             }
 
-            this._fileUtils.listAllSessions(sessionDirectory, false, (file, info) => {
+            FileUtils.listAllSessions(sessionDirectory, false, (file, info) => {
                 const filename = info.get_name();
                 const path = file.get_path();
                 if (!sessionNames.has(filename) && path && GLib.file_test(path, GLib.FileTest.EXISTS)) {
-                    this._fileUtils.removeFile(path);
+                    FileUtils.removeFile(path);
                 }
             });
         } catch (e) {
@@ -447,12 +446,12 @@ export const OpenWindowsTracker = class {
         // the app name outside this function. (See: shell-app.c -> shell_app_get_name -> window_backed_app_get_window: g_assert (app->running_state->windows))
         this._log.debug(`${appName} was closed. Cleaning up its saved session files.`);
 
-        this._fileUtils.removeFile(sessionDirectory, true);
+        FileUtils.removeFile(sessionDirectory, true);
 
         const possibleOrphanFolder = `${FileUtils.current_session_path}/${window.get_wm_class_instance()}`;
         if (GLib.file_test(possibleOrphanFolder, GLib.FileTest.EXISTS)) {
             this._log.debug(`Removing orphan session folder ${possibleOrphanFolder}`)
-            this._fileUtils.removeFile(possibleOrphanFolder, true);
+            FileUtils.removeFile(possibleOrphanFolder, true);
         }
     }
 

--- a/prefs.js
+++ b/prefs.js
@@ -1,283 +1,296 @@
 'use strict';
 
-const { Gtk, GObject, Gio, GLib, Gdk, GdkWayland } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk';
+import GdkWayland from 'gi://GdkWayland';
+import Gdk from 'gi://Gdk';
 
-const FileUtils = Me.imports.utils.fileUtils;
-const Log = Me.imports.utils.log;
-const GnomeVersion = Me.imports.utils.gnomeVersion;
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-Me.imports.utils.string;
+import * as FileUtils from './utils/fileUtils.js';
+import * as Log from './utils/log.js';
+import * as GnomeVersion from './utils/gnomeVersion.js';
 
-const PrefsCloseWindow = Me.imports.prefsCloseWindow;
+import * as string from './utils/string.js';
 
-const Prefs = GObject.registerClass(
-    {
-        GTypeName: 'AnotherWindowSessionManagerPrefs',
-    },
-    class Prefs extends GObject.Object {
-        _init() {
-            Gtk.init()
-            
-            // gsettings
-            this._settings = ExtensionUtils.getSettings(
-                'org.gnome.shell.extensions.another-window-session-manager');
+import * as PrefsCloseWindow from './prefsCloseWindow.js';
 
-            this._log = new Log.Log();
 
-            this.render_ui();
-            new PrefsCloseWindow.UICloseWindows(this._builder).init();
-            this._bindSettings();
-            
-            // Set sensitive AFTER this._bindSettings() to make it work
-            this._setSensitive();
-        }
+export default class AnotherWindowSessionManagerPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        window.set_default_size(1000, 800);
+        
+        // gsettings
+        this._settings = this.getSettings('org.gnome.shell.extensions.another-window-session-manager');
+        this._fileUtils = new FileUtils.FileUtils();
 
-        _setSensitive() {
-            const activeOfRestorePrevious = this.restore_previous_switch.get_active();
-            this.restore_previous_delay_spinbutton.set_sensitive(activeOfRestorePrevious);
+        this._log = new Log.Log();
 
-            const restore_at_startup_switch_state = this.restore_at_startup_switch.get_active();
-            this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(restore_at_startup_switch_state);
-            this.restore_at_startup_without_asking_switch.set_sensitive(restore_at_startup_switch_state);
-            this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(
-                restore_at_startup_switch_state && !this.restore_at_startup_without_asking_switch.get_active()
-            );
+        this.render_ui();
+        new PrefsCloseWindow.UICloseWindows(this._builder).init();
+        this._bindSettings();
+        
+        // Set sensitive AFTER this._bindSettings() to make it work
+        this._setSensitive();
 
-            const display = Gdk.Display.get_default();
-            if (display instanceof GdkWayland.WaylandDisplay) {
-                this.stash_and_restore_states_switch.set_sensitive(false);
-            }
-        }
+        this._addPages(window);
+    }
 
-        _bindSettings() {
-            this._settings.bind(
-                'debugging-mode',
-                this.debugging_mode_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
+    _addPages(window) {
+        const pages = [
+            this._builder.get_object('close_windows_page'),
+            this._builder.get_object('save_windows_page'),
+            this._builder.get_object('restore_sessions_page'),
+            this._builder.get_object('general_page'),
+        ];
+        pages.forEach(page => window.add(page));
+    }
 
-            this._settings.bind(
-                'show-indicator',
-                this.show_indicator_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
+    _setSensitive() {
+        const activeOfRestorePrevious = this.restore_previous_switch.get_active();
+        this.restore_previous_delay_spinbutton.set_sensitive(activeOfRestorePrevious);
 
-            this._settings.bind(
-                'enable-save-session-notification',
-                this.save_session_notification_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
+        const restore_at_startup_switch_state = this.restore_at_startup_switch.get_active();
+        this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(restore_at_startup_switch_state);
+        this.restore_at_startup_without_asking_switch.set_sensitive(restore_at_startup_switch_state);
+        this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(
+            restore_at_startup_switch_state && !this.restore_at_startup_without_asking_switch.get_active()
+        );
 
-            this._settings.bind(
-                'enable-autorestore-sessions',
-                this.restore_at_startup_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-            
-            this._settings.bind(
-                'enable-restore-previous-session',
-                this.restore_previous_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'restore-at-startup-without-asking',
-                this.restore_at_startup_without_asking_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'autorestore-sessions-timer',
-                this.timer_on_the_autostart_dialog_spinbutton,
-                'value',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'restore-previous-delay',
-                this.restore_previous_delay_spinbutton,
-                'value',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'restore-session-interval',
-                this.restore_session_interval_spinbutton,
-                'value',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'autostart-delay',
-                this.autostart_delay_spinbutton,
-                'value',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'restore-window-tiling',
-                this.restore_window_tiling_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'raise-windows-together',
-                this.raise_windows_together_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'stash-and-restore-states',
-                this.stash_and_restore_states_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'enable-autoclose-session',
-                this.auto_close_session_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.bind(
-                'enable-close-by-rules',
-                this.close_by_rules_switch,
-                'active',
-                Gio.SettingsBindFlags.DEFAULT
-            );
-
-            this._settings.connect('changed::enable-autorestore-sessions', (settings) => {
-                if (this._settings.get_boolean('enable-autorestore-sessions')) {
-                    this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_at_autostart,
-                        FileUtils.autostart_restore_desktop_file_path);
-                }
-            });
-
-            this._settings.connect('changed::enable-restore-previous-session', (settings) => {
-                if (this._settings.get_boolean('enable-restore-previous-session')) {
-                    this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_previous_at_autostart,
-                        FileUtils.autostart_restore_previous_desktop_file_path);
-                }
-            });
-
-            this._settings.connect('changed::restore-at-startup-without-asking', (settings) => {
-                this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(
-                    !this._settings.get_boolean('restore-at-startup-without-asking')
-                );
-            });
-
-            this._settings.connect('changed::autostart-delay', (settings) => {
-                this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_at_autostart,
-                    FileUtils.autostart_restore_desktop_file_path);
-                this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_previous_at_autostart,
-                    FileUtils.autostart_restore_previous_desktop_file_path);
-            });
-
-        }
-
-        render_ui() {
-            this._builder = new Gtk.Builder();
-            this._builder.set_scope(new BuilderScope(this));
-            this._builder.add_from_file(Me.path + '/ui/prefs-gtk4.ui');
-            this.notebook = this._builder.get_object('prefs_notebook');
-
-            this.debugging_mode_switch = this._builder.get_object('debugging_mode_switch');
-            this.show_indicator_switch = this._builder.get_object('show_indicator_switch');
-
-            this.save_session_notification_switch = this._builder.get_object('save_session_notification_switch');
-
-            this.restore_session_interval_spinbutton = this._builder.get_object('restore_session_interval_spinbutton');
-            this.timer_on_the_autostart_dialog_spinbutton = this._builder.get_object('timer_on_the_autostart_dialog_spinbutton');
-            this.autostart_delay_spinbutton = this._builder.get_object('autostart_delay_spinbutton');
-            this.restore_window_tiling_switch = this._builder.get_object('restore_window_tiling_switch');
-            this.restore_window_tiling_switch.connect('notify::active', (widget) => {
-                const active = widget.active;
-                this.raise_windows_together_switch.set_sensitive(active);
-            });
-            this.raise_windows_together_switch = this._builder.get_object('raise_windows_together_switch');
-            this.stash_and_restore_states_switch = this._builder.get_object('stash_and_restore_states_switch');
-
-            this.restore_previous_delay_spinbutton = this._builder.get_object('restore_previous_delay_spinbutton');
-            this.restore_previous_switch = this._builder.get_object('restore_previous_switch');
-            this.restore_previous_switch.connect('notify::active', (widget) => {
-                const active = widget.active;
-                const activeOfRestoreAtStartup = this.restore_at_startup_switch.get_active();
-                if (activeOfRestoreAtStartup) {
-                    this.restore_at_startup_switch.set_active(!active);
-                }
-                this.restore_previous_delay_spinbutton.set_sensitive(active);
-            });
-            
-            this.restore_at_startup_switch = this._builder.get_object('restore_at_startup_switch');
-            this.restore_at_startup_switch.connect('notify::active', (widget) => {
-                const active = widget.active;
-                this.restore_at_startup_without_asking_switch.set_sensitive(active);
-                const enableTimerSpinButton = active && !this._settings.get_boolean('restore-at-startup-without-asking');
-                if (enableTimerSpinButton) {
-                    this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(true);
-                } else {
-                    this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(false);
-                }
-                
-                const activeOfRestorePrevious = this.restore_previous_switch.get_active();
-                if (activeOfRestorePrevious) {
-                    this.restore_previous_switch.set_active(!active);
-                }
-            });
-
-            this.restore_at_startup_without_asking_switch = this._builder.get_object('restore_at_startup_without_asking_switch');
-            this.restore_at_startup_without_asking_switch.connect('notify::active', (widget) => {
-                const active = widget.active;
-                this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(!active);        
-            });
-
-            this.close_by_rules_switch = this._builder.get_object('close_by_rules_switch');
-            this.auto_close_session_switch = this._builder.get_object('auto_close_session_switch');
-
-        }
-
-        _installAutostartDesktopFile(desktopFileTemplate, targetDesktopFilePath) {
-            const argument = {
-                autostartDelay: this._settings.get_int('autostart-delay'),
-            };
-            const desktopFileContent = FileUtils.loadTemplate(desktopFileTemplate).fill(argument);
-            this._installDesktopFileToAutostartDir(targetDesktopFilePath, desktopFileContent);
-        }
-
-        _installDesktopFileToAutostartDir(desktopFilePath, desktopFileContents) {
-            const autostart_restore_desktop_file = Gio.File.new_for_path(desktopFilePath);
-            const autostart_restore_desktop_file_path_parent = autostart_restore_desktop_file.get_parent().get_path();
-            if (GLib.mkdir_with_parents(autostart_restore_desktop_file_path_parent, 0o744) === 0) {
-                let [success, tag] = autostart_restore_desktop_file.replace_contents(
-                    desktopFileContents,
-                    null,
-                    false,
-                    Gio.FileCreateFlags.REPLACE_DESTINATION,
-                    null
-                );
-    
-                if (success) {
-                    this._log.info(`Installed the autostart desktop file: ${desktopFilePath}!`);
-                } else {
-                    this._log.error(new Error(`Failed to install the autostart desktop file: ${desktopFilePath}`))
-                }
-            } else {
-                this._log.error(new Error(`Failed to create folder: ${autostart_restore_desktop_file_path_parent}`));
-            }
+        const display = Gdk.Display.get_default();
+        if (display instanceof GdkWayland.WaylandDisplay) {
+            this.stash_and_restore_states_switch.set_sensitive(false);
         }
     }
-);
+
+    _bindSettings() {
+        this._settings.bind(
+            'debugging-mode',
+            this.debugging_mode_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'show-indicator',
+            this.show_indicator_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'enable-save-session-notification',
+            this.save_session_notification_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'enable-autorestore-sessions',
+            this.restore_at_startup_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        
+        this._settings.bind(
+            'enable-restore-previous-session',
+            this.restore_previous_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'restore-at-startup-without-asking',
+            this.restore_at_startup_without_asking_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'autorestore-sessions-timer',
+            this.timer_on_the_autostart_dialog_spinbutton,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'restore-previous-delay',
+            this.restore_previous_delay_spinbutton,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'restore-session-interval',
+            this.restore_session_interval_spinbutton,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'autostart-delay',
+            this.autostart_delay_spinbutton,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'restore-window-tiling',
+            this.restore_window_tiling_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'raise-windows-together',
+            this.raise_windows_together_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'stash-and-restore-states',
+            this.stash_and_restore_states_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'enable-autoclose-session',
+            this.auto_close_session_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.bind(
+            'enable-close-by-rules',
+            this.close_by_rules_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this._settings.connect('changed::enable-autorestore-sessions', (settings) => {
+            if (this._settings.get_boolean('enable-autorestore-sessions')) {
+                this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_at_autostart,
+                    FileUtils.autostart_restore_desktop_file_path);
+            }
+        });
+
+        this._settings.connect('changed::enable-restore-previous-session', (settings) => {
+            if (this._settings.get_boolean('enable-restore-previous-session')) {
+                this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_previous_at_autostart,
+                    FileUtils.autostart_restore_previous_desktop_file_path);
+            }
+        });
+
+        this._settings.connect('changed::restore-at-startup-without-asking', (settings) => {
+            this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(
+                !this._settings.get_boolean('restore-at-startup-without-asking')
+            );
+        });
+
+        this._settings.connect('changed::autostart-delay', (settings) => {
+            this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_at_autostart,
+                FileUtils.autostart_restore_desktop_file_path);
+            this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_previous_at_autostart,
+                FileUtils.autostart_restore_previous_desktop_file_path);
+        });
+
+    }
+
+    render_ui() {
+        this._builder = new Gtk.Builder();
+        this._builder.set_scope(new BuilderScope(this));
+        this._builder.add_from_file(this.path + '/ui/prefs-gtk4.ui');
+
+        this.debugging_mode_switch = this._builder.get_object('debugging_mode_switch');
+        this.show_indicator_switch = this._builder.get_object('show_indicator_switch');
+
+        this.save_session_notification_switch = this._builder.get_object('save_session_notification_switch');
+
+        this.restore_session_interval_spinbutton = this._builder.get_object('restore_session_interval_spinbutton');
+        this.timer_on_the_autostart_dialog_spinbutton = this._builder.get_object('timer_on_the_autostart_dialog_spinbutton');
+        this.autostart_delay_spinbutton = this._builder.get_object('autostart_delay_spinbutton');
+        this.restore_window_tiling_switch = this._builder.get_object('restore_window_tiling_switch');
+        this.restore_window_tiling_switch.connect('notify::active', (widget) => {
+            const active = widget.active;
+            this.raise_windows_together_switch.set_sensitive(active);
+        });
+        this.raise_windows_together_switch = this._builder.get_object('raise_windows_together_switch');
+        this.stash_and_restore_states_switch = this._builder.get_object('stash_and_restore_states_switch');
+
+        this.restore_previous_delay_spinbutton = this._builder.get_object('restore_previous_delay_spinbutton');
+        this.restore_previous_switch = this._builder.get_object('restore_previous_switch');
+        this.restore_previous_switch.connect('notify::active', (widget) => {
+            const active = widget.active;
+            const activeOfRestoreAtStartup = this.restore_at_startup_switch.get_active();
+            if (activeOfRestoreAtStartup) {
+                this.restore_at_startup_switch.set_active(!active);
+            }
+            this.restore_previous_delay_spinbutton.set_sensitive(active);
+        });
+        
+        this.restore_at_startup_switch = this._builder.get_object('restore_at_startup_switch');
+        this.restore_at_startup_switch.connect('notify::active', (widget) => {
+            const active = widget.active;
+            this.restore_at_startup_without_asking_switch.set_sensitive(active);
+            const enableTimerSpinButton = active && !this._settings.get_boolean('restore-at-startup-without-asking');
+            if (enableTimerSpinButton) {
+                this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(true);
+            } else {
+                this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(false);
+            }
+            
+            const activeOfRestorePrevious = this.restore_previous_switch.get_active();
+            if (activeOfRestorePrevious) {
+                this.restore_previous_switch.set_active(!active);
+            }
+        });
+
+        this.restore_at_startup_without_asking_switch = this._builder.get_object('restore_at_startup_without_asking_switch');
+        this.restore_at_startup_without_asking_switch.connect('notify::active', (widget) => {
+            const active = widget.active;
+            this.timer_on_the_autostart_dialog_spinbutton.set_sensitive(!active);        
+        });
+
+        this.close_by_rules_switch = this._builder.get_object('close_by_rules_switch');
+        this.auto_close_session_switch = this._builder.get_object('auto_close_session_switch');
+
+    }
+
+    _installAutostartDesktopFile(desktopFileTemplate, targetDesktopFilePath) {
+        const argument = {
+            autostartDelay: this._settings.get_int('autostart-delay'),
+        };
+        const desktopFileContent = this._fileUtils.loadTemplate(desktopFileTemplate).fill(argument);
+        this._installDesktopFileToAutostartDir(targetDesktopFilePath, desktopFileContent);
+    }
+
+    _installDesktopFileToAutostartDir(desktopFilePath, desktopFileContents) {
+        const autostart_restore_desktop_file = Gio.File.new_for_path(desktopFilePath);
+        const autostart_restore_desktop_file_path_parent = autostart_restore_desktop_file.get_parent().get_path();
+        if (GLib.mkdir_with_parents(autostart_restore_desktop_file_path_parent, 0o744) === 0) {
+            let [success, tag] = autostart_restore_desktop_file.replace_contents(
+                desktopFileContents,
+                null,
+                false,
+                Gio.FileCreateFlags.REPLACE_DESTINATION,
+                null
+            );
+
+            if (success) {
+                this._log.info(`Installed the autostart desktop file: ${desktopFilePath}!`);
+            } else {
+                this._log.error(new Error(`Failed to install the autostart desktop file: ${desktopFilePath}`))
+            }
+        } else {
+            this._log.error(new Error(`Failed to create folder: ${autostart_restore_desktop_file_path_parent}`));
+        }
+    }
+}
+
 
 const BuilderScope = GObject.registerClass({
     // Should be a globally unique GType name

--- a/prefs.js
+++ b/prefs.js
@@ -24,7 +24,6 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
         
         // gsettings
         this._settings = this.getSettings('org.gnome.shell.extensions.another-window-session-manager');
-        this._fileUtils = new FileUtils.FileUtils();
 
         this._log = new Log.Log();
 
@@ -173,14 +172,14 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
 
         this._settings.connect('changed::enable-autorestore-sessions', (settings) => {
             if (this._settings.get_boolean('enable-autorestore-sessions')) {
-                this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_at_autostart,
+                this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_at_autostart,
                     FileUtils.autostart_restore_desktop_file_path);
             }
         });
 
         this._settings.connect('changed::enable-restore-previous-session', (settings) => {
             if (this._settings.get_boolean('enable-restore-previous-session')) {
-                this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_previous_at_autostart,
+                this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_previous_at_autostart,
                     FileUtils.autostart_restore_previous_desktop_file_path);
             }
         });
@@ -192,9 +191,9 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
         });
 
         this._settings.connect('changed::autostart-delay', (settings) => {
-            this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_at_autostart,
+            this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_at_autostart,
                 FileUtils.autostart_restore_desktop_file_path);
-            this._installAutostartDesktopFile(this._fileUtils.desktop_template_path_restore_previous_at_autostart,
+            this._installAutostartDesktopFile(FileUtils.desktop_template_path_restore_previous_at_autostart,
                 FileUtils.autostart_restore_previous_desktop_file_path);
         });
 
@@ -264,7 +263,7 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
         const argument = {
             autostartDelay: this._settings.get_int('autostart-delay'),
         };
-        const desktopFileContent = this._fileUtils.loadTemplate(desktopFileTemplate).fill(argument);
+        const desktopFileContent = FileUtils.loadTemplate(desktopFileTemplate).fill(argument);
         this._installDesktopFileToAutostartDir(targetDesktopFilePath, desktopFileContent);
     }
 

--- a/prefs.js
+++ b/prefs.js
@@ -315,23 +315,3 @@ const BuilderScope = GObject.registerClass({
     }
 
 });
-
-function buildPrefsWidget() {
-    const settings = new Prefs();
-
-    if (GnomeVersion.isLessThan42()) {
-        const scroll = new Gtk.ScrolledWindow({ 
-            vexpand: true, 
-            hexpand: true,
-            hscrollbar_policy: Gtk.PolicyType.NEVER,
-            vscrollbar_policy: Gtk.PolicyType.AUTOMATIC
-        });
-        scroll.set_child(settings.notebook);
-        return scroll;
-    }
-    return settings.notebook;
-}
-
-function init() {
-
-}

--- a/prefsCloseWindow.js
+++ b/prefsCloseWindow.js
@@ -1,20 +1,21 @@
 'use strict';
 
-const { Gio, GLib, GObject, Gtk, Pango, Gdk } = imports.gi;
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk';
+import Pango from 'gi://Pango';
+import Gdk from 'gi://Gdk';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as CloseWindowsRule from './model/closeWindowsRule.js';
 
-const CloseWindowsRule = Me.imports.model.closeWindowsRule;
+import * as PrefsUtils from './utils/prefsUtils.js';
+import * as Log from './utils/log.js';
+import * as IconFinder from './utils/iconFinder.js';
 
-const PrefsUtils = Me.imports.utils.prefsUtils;
-const Log = Me.imports.utils.log;
-const GnomeVersion = Me.imports.utils.gnomeVersion;
-const IconFinder = Me.imports.utils.iconFinder;
-
-const PrefsWindowPickableEntry = Me.imports.prefsWindowPickableEntry;
-const PrefsWidgets = Me.imports.prefsWidgets;
-const PrefsColumnView = Me.imports.prefsColumnView;
+import * as PrefsWindowPickableEntry from './prefsWindowPickableEntry.js';
+import * as PrefsWidgets from './prefsWidgets.js';
+import * as PrefsColumnView from './prefsColumnView.js';
 
 
 // const _ = ExtensionUtils.gettext;
@@ -22,7 +23,7 @@ const PrefsColumnView = Me.imports.prefsColumnView;
 /**
  * Based on https://gitlab.gnome.org/GNOME/gnome-shell-extensions/-/blob/main/extensions/auto-move-windows/prefs.js
  */
-var UICloseWindows = GObject.registerClass(
+export const UICloseWindows = GObject.registerClass(
     class UICloseWindows extends GObject.Object {
         _init(builder) {
             super._init({
@@ -202,7 +203,7 @@ var UICloseWindows = GObject.registerClass(
         }
 
         _onAddAppActivated() {
-            const dialog = new AwsmNewRuleByAppDialog(this._builder.get_object('prefs_notebook').get_root());
+            const dialog = new AwsmNewRuleByAppDialog(this._builder.get_object('close_windows_page').get_root());
             dialog.connect('response', (dlg, id) => {
                 const appInfo = id === Gtk.ResponseType.OK
                     ? dialog.get_widget().get_app_info() : null;

--- a/prefsColumnView.js
+++ b/prefsColumnView.js
@@ -1,19 +1,16 @@
 'use strict';
 
-const { GObject, Gtk, Gio } = imports.gi;
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as PrefsWindowPickableEntry from './prefsWindowPickableEntry.js';
+import * as PrefsWidgets from './prefsWidgets.js';
 
-const CloseWindowsWhitelist = Me.imports.model.closeWindowsRule.CloseWindowsWhitelist;
-
-const PrefsWindowPickableEntry = Me.imports.prefsWindowPickableEntry;
-const PrefsWidgets = Me.imports.prefsWidgets;
-
-const PrefsUtils = Me.imports.utils.prefsUtils;
+import * as PrefsUtils from './utils/prefsUtils.js';
 
 
-var ColumnView = GObject.registerClass({
+export const ColumnView = GObject.registerClass({
     Signals: {
         'activate': {
             param_types: [Gtk.CheckButton, GObject.TYPE_OBJECT]
@@ -98,7 +95,7 @@ var ColumnView = GObject.registerClass({
 
 });
 
-var WhitelistColumnView = GObject.registerClass({
+export const WhitelistColumnView = GObject.registerClass({
     Signals: {}, 
     Properties: {},
 }, class WhitelistColumnView extends ColumnView {

--- a/prefsWidgets.js
+++ b/prefsWidgets.js
@@ -1,14 +1,13 @@
 'use strict';
 
-const { Gtk, GLib, GObject } = imports.gi;
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import GLib from 'gi://GLib';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const GnomeVersion = Me.imports.utils.gnomeVersion;
+import * as GnomeVersion from './utils/gnomeVersion.js';
 
 
-var boxProperties = {
+export const boxProperties = {
     spacing: 0,
     margin_start: 6,
     margin_end: 6,
@@ -18,7 +17,7 @@ var boxProperties = {
     margin_bottom: 0,
 };
 
-var newColumnViewColumn = function(title, factorySetupFunc, factoryBindFunc) {
+export const newColumnViewColumn = function(title, factorySetupFunc, factoryBindFunc) {
     const factory = new Gtk.SignalListItemFactory();
     const columnViewColumn = new Gtk.ColumnViewColumn({
         title,
@@ -39,15 +38,15 @@ var newColumnViewColumn = function(title, factorySetupFunc, factoryBindFunc) {
     return columnViewColumn;
 }
 
-var newRemoveButton = function() {
+export const newRemoveButton = function() {
     return new BoxRemoveButton();
 }
 
-var newLabelSwitch = function(text, tooltipText, active) {
+export const newLabelSwitch = function(text, tooltipText, active) {
     return new LabelSwitch(text, tooltipText, active);
 }
 
-var updateStyle = function(widget, css) {
+export const updateStyle = function(widget, css) {
     const cssProvider = new Gtk.CssProvider();
     if (GnomeVersion.isLessThan44()) {
         cssProvider.load_from_data(css);
@@ -57,7 +56,7 @@ var updateStyle = function(widget, css) {
     widget.get_style_context().add_provider(cssProvider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 }
 
-var _newBox = function(properties) {
+export const _newBox = function(properties) {
     const box = new Gtk.Box({
         spacing: 6,
         margin_top: 6,
@@ -69,7 +68,7 @@ var _newBox = function(properties) {
     return box;
 }
 
-var _newDropDown = function(values, activeValue) {
+export const _newDropDown = function(values, activeValue) {
     const dropDownValues = values.map(cv => cv[1]);
     const dropDown = Gtk.DropDown.new_from_strings(dropDownValues);
     dropDown.set_valign(Gtk.Align.BASELINE);
@@ -89,7 +88,7 @@ var _newDropDown = function(values, activeValue) {
     return dropDown;
 }
 
-var LabelSwitch = GObject.registerClass({
+export const LabelSwitch = GObject.registerClass({
     Signals: {
         'active': {
             param_types: [GObject.TYPE_BOOLEAN, Gtk.Switch]
@@ -147,7 +146,7 @@ var LabelSwitch = GObject.registerClass({
 
 });
 
-var BoxRemoveButton = GObject.registerClass({
+export const BoxRemoveButton = GObject.registerClass({
     Signals: {'clicked': {}}
 }, class BoxRemoveButton extends Gtk.Box {
 
@@ -170,4 +169,21 @@ var BoxRemoveButton = GObject.registerClass({
     }
 
 });
+
+// TODO This function does not work
+export const addScrolledWindow = function(widget) {
+    const scroll = new Gtk.ScrolledWindow({ 
+        vexpand: true, 
+        hexpand: true,
+        hscrollbar_policy: Gtk.PolicyType.NEVER,
+        vscrollbar_policy: Gtk.PolicyType.AUTOMATIC
+    });
+    
+    const parent = widget.get_parent();
+    widget.unparent();
+    scroll.set_child(widget);
+    // How to add widget to Adw.PreferencesPage. parent is a Adw.PreferencesPage?
+    parent.add_child(scroll);
+
+}
 

--- a/prefsWindowPickableEntry.js
+++ b/prefsWindowPickableEntry.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const { Gio, GObject, Gtk, Pango } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import Pango from 'gi://Pango';
 
-const PrefsWidgets = Me.imports.prefsWidgets;
+import * as PrefsWidgets from './prefsWidgets.js';
 
 
-var WindowPickableEntry = GObject.registerClass({
+export const WindowPickableEntry = GObject.registerClass({
     Signals: {
         'entry-changed': {
             param_types: [Gtk.Entry]

--- a/saveSession.js
+++ b/saveSession.js
@@ -35,7 +35,6 @@ export const SaveSession = class {
 
         this._prefsUtils = new PrefsUtils.PrefsUtils();
         this._settings = this._prefsUtils.getSettings();
-        this._fileUtils = new FileUtils.FileUtils();
 
         this._sourceIds = [];
     }
@@ -350,7 +349,7 @@ export const SaveSession = class {
             };
 
             const desktopFileName = '__' + appName + '.desktop';
-            const desktopFileContent = this._fileUtils.loadDesktopTemplate(cancellable).fill(argument);
+            const desktopFileContent = FileUtils.loadDesktopTemplate(cancellable).fill(argument);
             if (!desktopFileContent) {
                 const errMsg = `Failed to generate a .desktop file ${desktopFileName} using ${JSON.stringify(argument)}`;
                 this._log.error(new Error(errMsg));
@@ -368,14 +367,14 @@ export const SaveSession = class {
 
     async backupExistingSessionIfNecessary(sessionName, baseDir) {
 
-        const sessions_path = this._fileUtils.get_sessions_path();
+        const sessions_path = FileUtils.get_sessions_path();
         const session_file_path = GLib.build_filenamev([sessions_path, sessionName]);
         const session_file = Gio.File.new_for_path(session_file_path);
         // Backup first if exists
         if (GLib.file_test(session_file_path, GLib.FileTest.EXISTS)) {
             this._log.debug(`Backing up existing session ${sessionName}`);
 
-            const session_file_backup_path = this._fileUtils.get_sessions_backups_path();
+            const session_file_backup_path = FileUtils.get_sessions_backups_path();
             const session_file_backup = GLib.build_filenamev([session_file_backup_path, sessionName + '.backup-' + new Date().getTime()]);
             if (GLib.mkdir_with_parents(session_file_backup_path, 0o744) !== 0) {
                 const errMsg = `Cannot save session: ${session_file_path}`;
@@ -416,7 +415,7 @@ export const SaveSession = class {
             return Promise.resolve(false);
         }
 
-        const sessions_path = this._fileUtils.get_sessions_path(baseDir);
+        const sessions_path = FileUtils.get_sessions_path(baseDir);
         const session_file_path = GLib.build_filenamev([sessions_path, sessionConfig.session_name]);
         const sessionFile = Gio.File.new_for_path(session_file_path);
 

--- a/ui/autoclose.js
+++ b/ui/autoclose.js
@@ -1,37 +1,32 @@
 
 'use strict';
 
-const { Clutter, Gio, GLib, GObject, Meta, Shell, St, Atk, Pango } = imports.gi;
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Shell from 'gi://Shell';
+import St from 'gi://St';
+import Atk from 'gi://Atk';
+import Pango from 'gi://Pango';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as CloseSession from '../closeSession.js';
 
-const CloseSession = Me.imports.closeSession;
+import * as EndSessionDialog from 'resource:///org/gnome/shell/ui/endSessionDialog.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as DND from 'resource:///org/gnome/shell/ui/dnd.js';
+import * as Layout from 'resource:///org/gnome/shell/ui/layout.js';
+import * as Dialog from 'resource:///org/gnome/shell/ui/dialog.js';
 
-const EndSessionDialog = imports.ui.endSessionDialog;
-const DND = imports.ui.dnd;
-
-const Gettext = imports.gettext;
-
-const Dialog = imports.ui.dialog;
-const ModalDialog = imports.ui.modalDialog;
-const Layout = imports.ui.layout;
-const Main = imports.ui.main;
-
-const Log = Me.imports.utils.log;
+import * as Log from '../utils/log.js';
 
 let GTop = null;
 try {
-    GTop = imports.gi.GTop;
+    GTop = await import('gi://GTop');
 } catch (e) {
     Log.Log.getDefault().error(e, `GTop is not installed, I highly recommend to install it, so that a process can be closed safely. How to install it? Please visit: https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager#dependencies .`);
 }
 
-const PrefsUtils = Me.imports.utils.prefsUtils;
-const FileUtils = Me.imports.utils.fileUtils;
-const SubprocessUtils = Me.imports.utils.subprocessUtils;
-
-const UiHelper = Me.imports.ui.uiHelper;
+import * as PrefsUtils from '../utils/prefsUtils.js';
 
 
 var sessionClosedByUser = false;
@@ -51,7 +46,7 @@ const callFunc = function (thisObj, func, param) {
     }
 }
 
-var State = {
+const State = {
     OPENED: 0,
     CLOSED: 1,
     OPENING: 2,
@@ -62,7 +57,7 @@ var State = {
     CONFIRMED: 7
 };
 
-var Autoclose = GObject.registerClass(
+export const Autoclose = GObject.registerClass(
     class Autoclose extends GObject.Object {
         _init() {
 
@@ -78,6 +73,10 @@ var Autoclose = GObject.registerClass(
         }
 
         _overrideEndSessionDialog() {
+            // Gnome 45.0 does not export EndSessionDialog.EndSessionDialog
+            if (!EndSessionDialog.EndSessionDialog) {
+                return;
+            }
             __confirm = EndSessionDialog.EndSessionDialog.prototype._confirm;
             __init = EndSessionDialog.EndSessionDialog.prototype._init;
             _addButton = EndSessionDialog.EndSessionDialog.prototype.addButton;
@@ -249,7 +248,7 @@ var Autoclose = GObject.registerClass(
 
 
 // Based on dialog.js of gnome-shell
-var RunningApplicationListWindow = GObject.registerClass({
+const RunningApplicationListWindow = GObject.registerClass({
     Signals: { 'opened': {}, 'closed': {} }
 },
     class RunningApplicationListWindow extends St.BoxLayout {

--- a/ui/autoclose.js
+++ b/ui/autoclose.js
@@ -28,8 +28,10 @@ try {
 
 import * as PrefsUtils from '../utils/prefsUtils.js';
 
-
-var sessionClosedByUser = false;
+// In ESM, we put variables like `sessionClosedByUser` in an object to share them crossing modules
+export const autocloseObject = {
+    sessionClosedByUser: false
+}
 
 let __confirm = null;
 let __init = null;
@@ -126,7 +128,7 @@ export const Autoclose = GObject.registerClass(
 
             EndSessionDialog.EndSessionDialog.prototype._confirm = async function (signal) {
                 try {
-                    sessionClosedByUser = true;
+                    autocloseObject.sessionClosedByUser = true;
 
                     const enableAutocloseSession = that._settings.get_boolean('enable-autoclose-session');
                     if (!enableAutocloseSession) {

--- a/ui/autostart.js
+++ b/ui/autostart.js
@@ -228,7 +228,6 @@ const AutostartDialog = GObject.registerClass(
             });
 
             this._settings = new PrefsUtils.PrefsUtils().getSettings();
-            this._fileUtils = new FileUtils.FileUtils();
 
             this._sessionName = this._settings.get_string(PrefsUtils.SETTINGS_AUTORESTORE_SESSIONS);
 
@@ -277,7 +276,7 @@ const AutostartDialog = GObject.registerClass(
                 return;
                 
             if (this._sessionName) {
-                const [exists, sessionFilePath] = this._fileUtils.sessionExists(this._sessionName);
+                const [exists, sessionFilePath] = FileUtils.sessionExists(this._sessionName);
                 if (exists) {
                     this._startTimer();
                     this._sync();

--- a/ui/autostart.js
+++ b/ui/autostart.js
@@ -31,7 +31,6 @@ export const AutostartServiceProvider = GObject.registerClass(
             super._init();
 
             this._log = new Log.Log();
-            this._fileUtils = new FileUtils.FileUtils();
 
             const extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
             this._autostartDbusXml = new TextDecoder().decode(
@@ -229,6 +228,7 @@ const AutostartDialog = GObject.registerClass(
             });
 
             this._settings = new PrefsUtils.PrefsUtils().getSettings();
+            this._fileUtils = new FileUtils.FileUtils();
 
             this._sessionName = this._settings.get_string(PrefsUtils.SETTINGS_AUTORESTORE_SESSIONS);
 
@@ -262,7 +262,7 @@ const AutostartDialog = GObject.registerClass(
         }
 
         _confirm() {
-            Autoclose.sessionClosedByUser = false;
+            Autoclose.autocloseObject.sessionClosedByUser = false;
             const _restoreSession = new RestoreSession.RestoreSession();
             _restoreSession.restoreSession(this._sessionName);
         }

--- a/ui/button.js
+++ b/ui/button.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const { GObject, St, Clutter } = imports.gi;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as IconFinder from '../utils/iconFinder.js';
 
-const IconFinder = Me.imports.utils.iconFinder;
 
-var Button = GObject.registerClass(
+export const Button = GObject.registerClass(
 class Button extends GObject.Object {
 
     _init(properties) {

--- a/ui/popupMenuButtonItems.js
+++ b/ui/popupMenuButtonItems.js
@@ -143,7 +143,7 @@ class PopupMenuButtonItemClose extends PopupMenuButtonItem {
                 Main.overview.toggle();
             }
 
-            RestoreSession.restoringApps.clear();
+            RestoreSession.restoreSessionObject.restoringApps.clear();
             this.closeSession.closeWindows();
             this._hideConfirm();
 

--- a/ui/popupMenuButtonItems.js
+++ b/ui/popupMenuButtonItems.js
@@ -1,25 +1,23 @@
 'use strict';
 
-const { GObject, St, Clutter } = imports.gi;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-const PopupMenu = imports.ui.popupMenu;
+import * as SaveSession from '../saveSession.js';
+import * as CloseSession from '../closeSession.js';
+import * as RestoreSession from '../restoreSession.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as FileUtils from '../utils/fileUtils.js';
+import * as Log from '../utils/log.js';
 
-const SaveSession = Me.imports.saveSession;
-const CloseSession = Me.imports.closeSession;
-const RestoreSession = Me.imports.restoreSession;
+import {Button} from './button.js';
 
-const IconFinder = Me.imports.utils.iconFinder;
-const FileUtils = Me.imports.utils.fileUtils;
-const Log = Me.imports.utils.log;
 
-const { Button } = Me.imports.ui.button;
-
-var PopupMenuButtonItems = GObject.registerClass(
+export const PopupMenuButtonItems = GObject.registerClass(
 class PopupMenuButtonItems extends GObject.Object {
 
     _init() {
@@ -39,7 +37,7 @@ class PopupMenuButtonItems extends GObject.Object {
 });
 
 
-var PopupMenuButtonItem = GObject.registerClass(
+const PopupMenuButtonItem = GObject.registerClass(
 class PopupMenuButtonItem extends PopupMenu.PopupMenuItem {
 
     _init() {
@@ -99,7 +97,7 @@ class PopupMenuButtonItem extends PopupMenu.PopupMenuItem {
 });
 
 
-var PopupMenuButtonItemClose = GObject.registerClass(
+const PopupMenuButtonItemClose = GObject.registerClass(
 class PopupMenuButtonItemClose extends PopupMenuButtonItem {
 
     _init(iconSymbolic) {
@@ -221,7 +219,7 @@ class PopupMenuButtonItemClose extends PopupMenuButtonItem {
 });
 
 
-var PopupMenuButtonItemSave = GObject.registerClass(
+const PopupMenuButtonItemSave = GObject.registerClass(
 class PopupMenuButtonItemSave extends PopupMenuButtonItem {
 
     _init(iconSymbolic) {
@@ -235,6 +233,8 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
         this._addYesAndNoButtons();
 
         this._log = new Log.Log();
+        this._fileUtils = new FileUtils.FileUtils();
+
         this._saveSession = new SaveSession.SaveSession(true);
 
         this._timeline = this.createTimeLine();
@@ -375,7 +375,7 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
             return [false, `ERROR: ${sessionName} is a reserved word, can't be used.`];
         }
 
-        if (FileUtils.isDirectory(sessionName)) {
+        if (this._fileUtils.isDirectory(sessionName)) {
             return [false, `ERROR: Can't save windows using '${sessionName}', it's an existing directory!`];
         }
 

--- a/ui/popupMenuButtonItems.js
+++ b/ui/popupMenuButtonItems.js
@@ -233,7 +233,6 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
         this._addYesAndNoButtons();
 
         this._log = new Log.Log();
-        this._fileUtils = new FileUtils.FileUtils();
 
         this._saveSession = new SaveSession.SaveSession(true);
 
@@ -375,7 +374,7 @@ class PopupMenuButtonItemSave extends PopupMenuButtonItem {
             return [false, `ERROR: ${sessionName} is a reserved word, can't be used.`];
         }
 
-        if (this._fileUtils.isDirectory(sessionName)) {
+        if (FileUtils.isDirectory(sessionName)) {
             return [false, `ERROR: Can't save windows using '${sessionName}', it's an existing directory!`];
         }
 

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -29,8 +29,8 @@
     <property name="title" translatable="yes">Close windows</property>
     <child>
       <object class="GtkScrolledWindow">
-        <property name="hscrollbar_policy">Always</property>
-        <property name="vscrollbar_policy">Always</property>
+        <property name="hscrollbar_policy">always</property>
+        <property name="vscrollbar_policy">always</property>
         <child>
           <object class="GtkViewport">
             <property name="focusable">False</property>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -23,267 +23,36 @@
     <property name="page-increment">10</property>
   </object>
 
-  <object class="GtkNotebook" id="prefs_notebook">
-    <property name="focusable">0</property>
+  <object class="AdwPreferencesPage" id="close_windows_page">
+    <!-- <property name="icon-name">text-x-generic-symbolic</property> -->
+    <property name="use_underline">true</property>
+    <property name="title" translatable="yes">Close windows</property>
     <child>
-      <object class="GtkNotebookPage">
-        <property name="child">
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
+      <object class="GtkScrolledWindow">
+        <property name="hscrollbar_policy">Always</property>
+        <property name="vscrollbar_policy">Always</property>
+        <child>
+          <object class="GtkViewport">
+            <property name="focusable">False</property>
+            <property name="vexpand">True</property>
             <child>
-              <object class="GtkListBox">
-                <child>
-                  <object class="GtkListBoxRow" id="auto_close_session_multi_row">
-                    <property name="focusable">1</property>
-                    <property name="child">
-                      <object class="GtkGrid" id="auto_close_session_multi_grid1">
-                        <property name="margin-top">12</property>
-                        <property name="margin-bottom">12</property>
-                        <property name="row-spacing">6</property>
-                        <property name="column-spacing">32</property>
-                        <child>
-                          <object class="GtkLabel" id="auto_close_session_multi_label">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Auto close session</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">0</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="auto_close_session_switch">
-                            <property name="focusable">1</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                            <layout>
-                              <property name="column">1</property>
-                              <property name="row">0</property>
-                              <property name="row-span">2</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="auto_close_session_multi_label_description">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Enable to close running apps and windows while Logout, Reboot and Shutdown via endSessionDialog.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">1</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkListBoxRow" id="close_by_rules_multi_row">
-                    <property name="focusable">1</property>
-                    <property name="child">
-                      <object class="GtkGrid" id="close_by_rules_multi_grid1">
-                        <property name="margin-top">12</property>
-                        <property name="margin-bottom">12</property>
-                        <property name="row-spacing">6</property>
-                        <property name="column-spacing">32</property>
-                        <child>
-                          <object class="GtkLabel" id="close_by_rules_multi_label">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Close by rules</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">0</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="close_by_rules_switch">
-                            <property name="focusable">1</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                            <layout>
-                              <property name="column">1</property>
-                              <property name="row">0</property>
-                              <property name="row-span">2</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="close_by_rules_multi_label_description">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">To make this feature work, see: &lt;a href='https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager#how-to-make-close-by-rules-work'&gt;How to make `Close by rules` work&lt;/a&gt;</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">1</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox">
+              <object class="GtkBox" id="close_windows_box">
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkListBox" id="close_by_rules_applications_list_box">
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="show-separators">True</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkListBox" id="close_by_rules_keywords_list_box">
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="show-separators">True</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkListBox" id="close_windows_whitelist_listbox">
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="show-separators">True</property>
-                    <child>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Close windows</property>
-          </object>
-        </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkNotebookPage">
-        <property name="position">1</property>
-        <property name="child">
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkFrame" id="save_session_notification_frame">
-                <property name="margin-top">30</property>
-                <property name="child">
                   <object class="GtkListBox">
                     <child>
-                      <object class="GtkListBoxRow">
+                      <object class="GtkListBoxRow" id="auto_close_session_multi_row">
                         <property name="focusable">1</property>
                         <property name="child">
-                          <object class="GtkGrid">
-                            <property name="margin-bottom">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="save_session_notification_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Session is saved notification</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="save_session_notification_switch">
-                                <property name="focusable">1</property>
-                                <property name="active">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">1</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Show a notification when users click buttons on the popup menu to save a session.</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-          </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Save windows</property>
-          </object>
-        </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkNotebookPage">
-        <property name="position">2</property>
-        <property name="child">
-          <object class="GtkBox">
-            <property name="margin-top">30</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkFrame" id="restore_previous_frame">
-                <property name="child">
-                  <object class="GtkListBox">
-                    <child>
-                      <object class="GtkListBoxRow" id="restore_previous_multi_row">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid">
+                          <object class="GtkGrid" id="auto_close_session_multi_grid1">
                             <property name="margin-top">12</property>
+                            <property name="margin-bottom">12</property>
                             <property name="row-spacing">6</property>
                             <property name="column-spacing">32</property>
-                            <property name="margin-top">12</property><child>
-                              <object class="GtkLabel">
+                            <child>
+                              <object class="GtkLabel" id="auto_close_session_multi_label">
                                 <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Restore previous apps and windows at startup</property>
+                                <property name="label" translatable="yes">Auto close session</property>
                                 <property name="use-markup">1</property>
                                 <property name="xalign">0</property>
                                 <layout>
@@ -293,7 +62,7 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkSwitch" id="restore_previous_switch">
+                              <object class="GtkSwitch" id="auto_close_session_switch">
                                 <property name="focusable">1</property>
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
@@ -305,9 +74,9 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkLabel">
+                              <object class="GtkLabel" id="auto_close_session_multi_label_description">
                                 <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Install ~/.config/autostart/_awsm-restore-previous-session.desktop if enabled</property>
+                                <property name="label" translatable="yes">Enable to close running apps and windows while Logout, Reboot and Shutdown via endSessionDialog.</property>
                                 <property name="wrap">True</property>
                                 <property name="use-markup">1</property>
                                 <property name="xalign">0</property>
@@ -320,22 +89,26 @@
                                 </layout>
                               </object>
                             </child>
+                            <child>
+                              <placeholder/>
+                            </child>
                           </object>
                         </property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkListBoxRow">
+                      <object class="GtkListBoxRow" id="close_by_rules_multi_row">
                         <property name="focusable">1</property>
                         <property name="child">
-                          <object class="GtkGrid" id="restore_previous_delay_multi_grid">
+                          <object class="GtkGrid" id="close_by_rules_multi_grid1">
+                            <property name="margin-top">12</property>
                             <property name="margin-bottom">12</property>
                             <property name="row-spacing">6</property>
                             <property name="column-spacing">32</property>
                             <child>
-                              <object class="GtkLabel" id="restore_previous_delay_multi_label">
+                              <object class="GtkLabel" id="close_by_rules_multi_label">
                                 <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Restore delay([0, 3600]s)</property>
+                                <property name="label" translatable="yes">Close by rules</property>
                                 <property name="use-markup">1</property>
                                 <property name="xalign">0</property>
                                 <layout>
@@ -345,12 +118,9 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkSpinButton" id="restore_previous_delay_spinbutton">
+                              <object class="GtkSwitch" id="close_by_rules_switch">
                                 <property name="focusable">1</property>
-                                <property name="text" translatable="yes">10</property>
-                                <property name="adjustment">restore_previous_delay_adjustment</property>
-                                <property name="numeric">1</property>
-                                <property name="value">10</property>
+                                <property name="halign">end</property>
                                 <property name="valign">center</property>
                                 <layout>
                                   <property name="column">1</property>
@@ -360,9 +130,9 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkLabel">
+                              <object class="GtkLabel" id="close_by_rules_multi_label_description">
                                 <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">5 by default.</property>
+                                <property name="label" translatable="yes">To make this feature work, see: &lt;a href='https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager#how-to-make-close-by-rules-work'&gt;How to make `Close by rules` work&lt;/a&gt;</property>
                                 <property name="wrap">True</property>
                                 <property name="use-markup">1</property>
                                 <property name="xalign">0</property>
@@ -375,30 +145,73 @@
                                 </layout>
                               </object>
                             </child>
+                            <child>
+                              <placeholder/>
+                            </child>
                           </object>
                         </property>
                       </object>
                     </child>
                   </object>
-                </property>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkListBox" id="close_by_rules_applications_list_box">
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="show-separators">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkListBox" id="close_by_rules_keywords_list_box">
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="show-separators">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkListBox" id="close_windows_whitelist_listbox">
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="show-separators">True</property>
+                        <child>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
-            <child>
-              <object class="GtkFrame" id="restore_window_frame">
-                <property name="margin-top">30</property>
-                <property name="child">
-                  <object class="GtkListBoxRow" id="restore_at_startup_multi_row">
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="AdwPreferencesPage" id="save_windows_page">
+    <property name="use_underline">true</property>
+    <property name="title" translatable="yes">Save windows</property>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkFrame" id="save_session_notification_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox">
+                <child>
+                  <object class="GtkListBoxRow">
                     <property name="focusable">1</property>
                     <property name="child">
-                      <object class="GtkGrid" id="restore_at_startup_multi_grid">
-                        <property name="margin-top">12</property>
+                      <object class="GtkGrid">
                         <property name="margin-bottom">12</property>
                         <property name="row-spacing">6</property>
                         <property name="column-spacing">32</property>
                         <child>
-                          <object class="GtkLabel" id="restore_at_startup_multi_label">
+                          <object class="GtkLabel" id="save_session_notification_label">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Restore selected session at startup</property>
+                            <property name="label" translatable="yes">Session is saved notification</property>
                             <property name="use-markup">1</property>
                             <property name="xalign">0</property>
                             <layout>
@@ -408,10 +221,12 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkSwitch" id="restore_at_startup_switch">
+                          <object class="GtkSwitch" id="save_session_notification_switch">
                             <property name="focusable">1</property>
+                            <property name="active">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
+                            <property name="hexpand">1</property>
                             <layout>
                               <property name="column">1</property>
                               <property name="row">0</property>
@@ -422,7 +237,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Install ~/.config/autostart/_gnome-shell-extension-another-window-session-manager.desktop if enabled</property>
+                            <property name="label" translatable="yes">Show a notification when users click buttons on the popup menu to save a session.</property>
                             <property name="wrap">True</property>
                             <property name="use-markup">1</property>
                             <property name="xalign">0</property>
@@ -435,430 +250,614 @@
                             </layout>
                           </object>
                         </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="AdwPreferencesPage" id="restore_sessions_page">
+    <property name="use_underline">true</property>
+    <property name="title" translatable="yes">Restore sessions</property>
+    <child>
+      <object class="GtkScrolledWindow">
+        <property name="hscrollbar_policy">never</property>
+        <child>
+          <object class="GtkViewport">
+            <property name="focusable">False</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkBox">
+                <property name="margin-top">30</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkFrame" id="restore_previous_frame">
+                    <property name="child">
+                      <object class="GtkListBox">
                         <child>
-                          <object class="GtkLabel" id="restore_at_startup_without_asking_multi_label">
+                          <object class="GtkListBoxRow" id="restore_previous_multi_row">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkGrid">
+                                <property name="margin-top">12</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">32</property>
+                                <property name="margin-top">12</property><child>
+                                  <object class="GtkLabel">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">Restore previous apps and windows at startup</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="restore_previous_switch">
+                                    <property name="focusable">1</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">0</property>
+                                      <property name="row-span">2</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">Install ~/.config/autostart/_awsm-restore-previous-session.desktop if enabled</property>
+                                    <property name="wrap">True</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">1</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkGrid" id="restore_previous_delay_multi_grid">
+                                <property name="margin-bottom">12</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">32</property>
+                                <child>
+                                  <object class="GtkLabel" id="restore_previous_delay_multi_label">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">Restore delay([0, 3600]s)</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="restore_previous_delay_spinbutton">
+                                    <property name="focusable">1</property>
+                                    <property name="text" translatable="yes">10</property>
+                                    <property name="adjustment">restore_previous_delay_adjustment</property>
+                                    <property name="numeric">1</property>
+                                    <property name="value">10</property>
+                                    <property name="valign">center</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">0</property>
+                                      <property name="row-span">2</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">5 by default.</property>
+                                    <property name="wrap">True</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">1</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="restore_window_frame">
+                    <property name="margin-top">30</property>
+                    <property name="child">
+                      <object class="GtkListBoxRow" id="restore_at_startup_multi_row">
+                        <property name="focusable">1</property>
+                        <property name="child">
+                          <object class="GtkGrid" id="restore_at_startup_multi_grid">
+                            <property name="margin-top">12</property>
+                            <property name="margin-bottom">12</property>
+                            <property name="row-spacing">6</property>
+                            <property name="column-spacing">32</property>
+                            <child>
+                              <object class="GtkLabel" id="restore_at_startup_multi_label">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Restore selected session at startup</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="restore_at_startup_switch">
+                                <property name="focusable">1</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                  <property name="row-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Install ~/.config/autostart/_gnome-shell-extension-another-window-session-manager.desktop if enabled</property>
+                                <property name="wrap">True</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">1</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="restore_at_startup_without_asking_multi_label">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Restore at startup without asking</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="restore_at_startup_without_asking_switch">
+                                <property name="focusable">1</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="timer_on_the_autostart_dialog_multi_label">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Timer on the autostart dialog([0, 3600]s)</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">3</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="timer_on_the_autostart_dialog_spinbutton">
+                                <property name="focusable">1</property>
+                                <property name="text" translatable="yes">10</property>
+                                <property name="adjustment">timer_on_the_autostart_dialog_adjustment</property>
+                                <property name="numeric">1</property>
+                                <property name="value">10</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">3</property>
+                                  <property name="row-span">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">10 by default.</property>
+                                <property name="wrap">True</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">4</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </property>
+                    <child type="label_item">
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="restore_session_interval_frame">
+                    <property name="margin-top">30</property>
+                    <property name="child">
+                      <object class="GtkListBox">
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkGrid">
+                                <property name="margin-top">12</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">32</property>
+                                <child>
+                                  <object class="GtkLabel" id="restore_session_interval_label">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">Restore applications interval([0, 300000]ms)</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="restore_session_interval_spinbutton">
+                                    <property name="focusable">1</property>
+                                    <property name="text" translatable="yes">10</property>
+                                    <property name="adjustment">restore_session_interval_spinbutton_adjustment</property>
+                                    <property name="numeric">1</property>
+                                    <property name="value">0</property>
+                                    <property name="valign">center</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">0</property>
+                                      <property name="row-span">2</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="restore_session_interval_label_description">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">0 by default. There's no need to set this option normally, unless the process of restoring session is too fast to freeze the system, for example.</property>
+                                    <property name="wrap">True</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">1</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkGrid">
+                                <property name="margin-bottom">12</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">32</property>
+                                <child>
+                                  <object class="GtkLabel" id="autostart_delay_multi_label">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">Autostart delay([0, 3600]s)</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSpinButton" id="autostart_delay_spinbutton">
+                                    <property name="focusable">1</property>
+                                    <property name="text" translatable="yes">20</property>
+                                    <property name="adjustment">autostart_delay_adjustment</property>
+                                    <property name="numeric">1</property>
+                                    <property name="value">20</property>
+                                    <property name="valign">center</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">0</property>
+                                      <property name="row-span">2</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="autostart_delay_multi_label_description">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">5 by default. Delay before restoring session at startup or the previous session. If the delay is too short, the computer might freeze.</property>
+                                    <property name="wrap">True</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">1</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="restore_window_tiling_frame">
+                    <property name="margin-top">30</property>
+                    <property name="child">
+                      <object class="GtkListBox">
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkBox">
+                                <child>
+                                  <object class="GtkLabel" id="restore_window_tiling_label">
+                                    <property name="label" translatable="yes">Restore window tiling</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="restore_window_tiling_switch">
+                                    <property name="focusable">1</property>
+                                    <property name="active">1</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <property name="hexpand">1</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkBox">
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="label" translatable="yes">Raise windows together</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="raise_windows_together_switch">
+                                    <property name="focusable">1</property>
+                                    <property name="active">1</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <property name="hexpand">1</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="stash_and_restore_states_frame">
+                    <property name="margin-top">30</property>
+                    <property name="child">
+                      <object class="GtkListBox">
+                        <child>
+                          <object class="GtkListBoxRow">
+                            <property name="focusable">1</property>
+                            <property name="child">
+                              <object class="GtkGrid">
+                                <property name="margin-bottom">12</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">32</property>
+                                <child>
+                                  <object class="GtkLabel" id="stash_and_restore_states_label">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">Restore windows states after Gnome Shell restarts</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">0</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="stash_and_restore_states_switch">
+                                    <property name="focusable">1</property>
+                                    <property name="active">1</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <property name="hexpand">1</property>
+                                    <layout>
+                                      <property name="column">1</property>
+                                      <property name="row">0</property>
+                                      <property name="row-span">2</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="hexpand">1</property>
+                                    <property name="label" translatable="yes">Only enabled on X11, since Wayand doesn't support restart Gnome Shell via `Alt+F2 then type r` or `killall -3 gnome-shell`.</property>
+                                    <property name="wrap">True</property>
+                                    <property name="use-markup">1</property>
+                                    <property name="xalign">0</property>
+                                    <property name="valign">center</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                    <layout>
+                                      <property name="column">0</property>
+                                      <property name="row">1</property>
+                                    </layout>
+                                  </object>
+                                </child>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="AdwPreferencesPage" id="general_page">
+    <property name="use_underline">true</property>
+    <property name="title" translatable="yes">General</property>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkFrame">
+            <property name="margin-top">30</property>
+            <property name="margin-bottom">12</property>
+            <child>
+              <object class="GtkListBox">
+                <property name="selection-mode">none</property>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkBox">
+                        <child>
+                          <object class="GtkLabel">
                             <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Restore at startup without asking</property>
+                            <property name="label" translatable="yes">Show indicator on the panel</property>
                             <property name="use-markup">1</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
-                              <property name="row">2</property>
+                              <property name="row">0</property>
                             </layout>
                           </object>
                         </child>
                         <child>
-                          <object class="GtkSwitch" id="restore_at_startup_without_asking_switch">
+                          <object class="GtkSwitch" id="show_indicator_switch">
                             <property name="focusable">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <layout>
                               <property name="column">1</property>
-                              <property name="row">2</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="timer_on_the_autostart_dialog_multi_label">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Timer on the autostart dialog([0, 3600]s)</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">3</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkSpinButton" id="timer_on_the_autostart_dialog_spinbutton">
-                            <property name="focusable">1</property>
-                            <property name="text" translatable="yes">10</property>
-                            <property name="adjustment">timer_on_the_autostart_dialog_adjustment</property>
-                            <property name="numeric">1</property>
-                            <property name="value">10</property>
-                            <layout>
-                              <property name="column">1</property>
-                              <property name="row">3</property>
-                              <property name="row-span">2</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">10 by default.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">4</property>
+                              <property name="row">0</property>
                             </layout>
                           </object>
                         </child>
                       </object>
                     </property>
                   </object>
-                </property>
-                <child type="label_item">
-                  <placeholder/>
                 </child>
               </object>
             </child>
-            <child>
-              <object class="GtkFrame" id="restore_session_interval_frame">
-                <property name="margin-top">30</property>
-                <property name="child">
-                  <object class="GtkListBox">
-                    <child>
-                      <object class="GtkListBoxRow">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid">
-                            <property name="margin-top">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="restore_session_interval_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Restore applications interval([0, 300000]ms)</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSpinButton" id="restore_session_interval_spinbutton">
-                                <property name="focusable">1</property>
-                                <property name="text" translatable="yes">10</property>
-                                <property name="adjustment">restore_session_interval_spinbutton_adjustment</property>
-                                <property name="numeric">1</property>
-                                <property name="value">0</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="restore_session_interval_label_description">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">0 by default. There's no need to set this option normally, unless the process of restoring session is too fast to freeze the system, for example.</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkListBoxRow">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid">
-                            <property name="margin-bottom">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="autostart_delay_multi_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Autostart delay([0, 3600]s)</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSpinButton" id="autostart_delay_spinbutton">
-                                <property name="focusable">1</property>
-                                <property name="text" translatable="yes">20</property>
-                                <property name="adjustment">autostart_delay_adjustment</property>
-                                <property name="numeric">1</property>
-                                <property name="value">20</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="autostart_delay_multi_label_description">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">5 by default. Delay before restoring session at startup or the previous session. If the delay is too short, the computer might freeze.</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFrame" id="restore_window_tiling_frame">
-                <property name="margin-top">30</property>
-                <property name="child">
-                  <object class="GtkListBox">
-                    <child>
-                      <object class="GtkListBoxRow">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkBox">
-                            <child>
-                              <object class="GtkLabel" id="restore_window_tiling_label">
-                                <property name="label" translatable="yes">Restore window tiling</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="restore_window_tiling_switch">
-                                <property name="focusable">1</property>
-                                <property name="active">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkListBoxRow">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkBox">
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label" translatable="yes">Raise windows together</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="raise_windows_together_switch">
-                                <property name="focusable">1</property>
-                                <property name="active">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">1</property>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                  </object>
-                </property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkFrame" id="stash_and_restore_states_frame">
-                <property name="margin-top">30</property>
-                <property name="child">
-                  <object class="GtkListBox">
-                    <child>
-                      <object class="GtkListBoxRow">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid">
-                            <property name="margin-bottom">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="stash_and_restore_states_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Restore windows states after Gnome Shell restarts</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="stash_and_restore_states_switch">
-                                <property name="focusable">1</property>
-                                <property name="active">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">1</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Only enabled on X11, since Wayand doesn't support restart Gnome Shell via `Alt+F2 then type r` or `killall -3 gnome-shell`.</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <property name="valign">center</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                  </object>
-                </property>
-              </object>
-            </child>
           </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">Restore sessions</property>
-          </object>
-        </property>
-      </object>
-    </child>
-    <child>
-      <object class="GtkNotebookPage">
-        <property name="child">
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkFrame">
-                <property name="margin-top">30</property>
-                <property name="margin-bottom">12</property>
+        </child>
+        <child>
+          <object class="GtkFrame" id="debugging_mode_frame">
+            <property name="child">
+              <object class="GtkListBox" id="debugging_mode_listbox">
+                <property name="selection-mode">none</property>
                 <child>
-                  <object class="GtkListBox">
-                    <property name="selection-mode">none</property>
-                    <child>
-                      <object class="GtkListBoxRow">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkBox">
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Show indicator on the panel</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="show_indicator_switch">
-                                <property name="focusable">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
+                  <object class="GtkListBoxRow" id="debugging_mode_multi_row">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkGrid" id="debugging_mode_multi_grid">
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="debugging_mode_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Debugging mode</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
-                        </property>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="debugging_mode_switch">
+                            <property name="focusable">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
                       </object>
-                    </child>
+                    </property>
                   </object>
                 </child>
               </object>
-            </child>
-            <child>
-              <object class="GtkFrame" id="debugging_mode_frame">
-                <property name="child">
-                  <object class="GtkListBox" id="debugging_mode_listbox">
-                    <property name="selection-mode">none</property>
-                    <child>
-                      <object class="GtkListBoxRow" id="debugging_mode_multi_row">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid" id="debugging_mode_multi_grid">
-                            <property name="margin-top">12</property>
-                            <property name="margin-bottom">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="debugging_mode_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Debugging mode</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="debugging_mode_switch">
-                                <property name="focusable">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </child>
-                  </object>
-                </property>
-                <child type="label_item">
-                  <placeholder/>
-                </child>
-              </object>
+            </property>
+            <child type="label_item">
+              <placeholder/>
             </child>
           </object>
-        </property>
-        <property name="tab">
-          <object class="GtkLabel">
-            <property name="label" translatable="yes">General</property>
-          </object>
-        </property>
+        </child>
       </object>
     </child>
   </object>

--- a/ui/searchSessionItem.js
+++ b/ui/searchSessionItem.js
@@ -1,16 +1,15 @@
 'use strict';
 
-const { GObject, St, Clutter, Atk } = imports.gi;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
 
-const PopupMenu = imports.ui.popupMenu;
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const Tooltip = Me.imports.utils.tooltip;
+import * as Tooltip from '../utils/tooltip.js';
 
 
-var SearchSessionItem = GObject.registerClass(
+export const SearchSessionItem = GObject.registerClass(
     class SearchSessionItem extends PopupMenu.PopupBaseMenuItem {
 
         _init() {

--- a/ui/sessionItem.js
+++ b/ui/sessionItem.js
@@ -1,15 +1,13 @@
 'use strict';
 
-const { GObject, St, Clutter, GLib } = imports.gi;
+import GObject from 'gi://GObject';
 
-const PopupMenu = imports.ui.popupMenu;
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as SessionItemButtons from '../ui/sessionItemButtons.js';
 
-const SessionItemButtons = Me.imports.ui.sessionItemButtons;
 
-var SessionItem = GObject.registerClass(
+export const SessionItem = GObject.registerClass(
 class SessionItem extends PopupMenu.PopupMenuItem {
     
     _init(fileInfo, file, indicator) {
@@ -49,7 +47,7 @@ class SessionItem extends PopupMenu.PopupMenuItem {
     
 });
 
-var EmptySessionItem = GObject.registerClass(
+const EmptySessionItem = GObject.registerClass(
 class EmptySessionItem extends PopupMenu.PopupMenuItem {
     
     _init() {

--- a/ui/sessionItemButtons.js
+++ b/ui/sessionItemButtons.js
@@ -33,7 +33,6 @@ class SessionItemButtons extends GObject.Object {
         super._init();
 
         this._log = new Log.Log();
-        this._fileUtils = new FileUtils.FileUtils();
 
         this.sessionItem = sessionItem;
 
@@ -103,9 +102,9 @@ class SessionItemButtons extends GObject.Object {
             markup: 'Open session file using an external editor',
         });
         viewButton.connect('clicked', () => {
-            const sessions_path = this._fileUtils.get_sessions_path();
+            const sessions_path = FileUtils.get_sessions_path();
             const session_file_path = GLib.build_filenamev([sessions_path, this.sessionItem._filename]);
-            this._fileUtils.findDefaultApp(session_file_path).then(([app, file]) => {
+            FileUtils.findDefaultApp(session_file_path).then(([app, file]) => {
                 try {
                     app.launch([file], global.create_app_launch_context(DateUtils.get_current_time(), -1));
                 } catch (error) {
@@ -123,7 +122,7 @@ class SessionItemButtons extends GObject.Object {
         });
         deleteButton.connect('clicked', () => {
             // We just trash file to trash scan instead of delete in case still need it.
-            this._fileUtils.trashSession(this.sessionItem._filename);
+            FileUtils.trashSession(this.sessionItem._filename);
         });
 
     }
@@ -149,7 +148,7 @@ class SessionItemButtons extends GObject.Object {
     }
 
     _addViewButton() {
-        const [exists, sessionFilePath] = this._fileUtils.sessionExists(this.sessionItem._filename);
+        const [exists, sessionFilePath] = FileUtils.sessionExists(this.sessionItem._filename);
         return this._addTextButton('View', exists);
     }
 

--- a/ui/sessionItemButtons.js
+++ b/ui/sessionItemButtons.js
@@ -1,39 +1,40 @@
 'use strict';
 
-const { GObject, St, Clutter, GLib } = imports.gi;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import GLib from 'gi://GLib';
+import Clutter from 'gi://Clutter';
 
-const Main = imports.ui.main;
-const PopupMenu = imports.ui.popupMenu;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as IconFinder from '../utils/iconFinder.js';
+import * as FileUtils from '../utils/fileUtils.js';
+import * as DateUtils from '../utils/dateUtils.js';
+import * as Tooltip from '../utils/tooltip.js';
+import * as GnomeVersion from '../utils/gnomeVersion.js';
+import * as Log from '../utils/log.js';
+import * as PrefsUtils from '../utils/prefsUtils.js';
 
-const IconFinder = Me.imports.utils.iconFinder;
-const FileUtils = Me.imports.utils.fileUtils;
-const DateUtils = Me.imports.utils.dateUtils;
-const Tooltip = Me.imports.utils.tooltip;
-const GnomeVersion = Me.imports.utils.gnomeVersion;
-const Log = Me.imports.utils.log;
+import * as SaveSession from '../saveSession.js';
+import * as RestoreSession from '../restoreSession.js';
+import * as MoveSession from '../moveSession.js';
+import * as CloseSession from '../closeSession.js';
 
-const SaveSession = Me.imports.saveSession;
-const RestoreSession = Me.imports.restoreSession;
-const MoveSession = Me.imports.moveSession;
-const CloseSession = Me.imports.closeSession;
+import {Button} from './button.js';
 
-const { Button } = Me.imports.ui.button;
-const Autoclose = Me.imports.ui.autoclose;
+import * as Autoclose from './autoclose.js';
 
-const PrefsUtils = Me.imports.utils.prefsUtils;
-const CommonError = Me.imports.utils.CommonError;
 
-var SessionItemButtons = GObject.registerClass(
+export const SessionItemButtons = GObject.registerClass(
 class SessionItemButtons extends GObject.Object {
 
     _init(sessionItem) {
         super._init();
 
         this._log = new Log.Log();
-        
+        this._fileUtils = new FileUtils.FileUtils();
+
         this.sessionItem = sessionItem;
 
         // TODO Nullify created object?
@@ -102,9 +103,9 @@ class SessionItemButtons extends GObject.Object {
             markup: 'Open session file using an external editor',
         });
         viewButton.connect('clicked', () => {
-            const sessions_path = FileUtils.get_sessions_path();
+            const sessions_path = this._fileUtils.get_sessions_path();
             const session_file_path = GLib.build_filenamev([sessions_path, this.sessionItem._filename]);
-            FileUtils.findDefaultApp(session_file_path).then(([app, file]) => {
+            this._fileUtils.findDefaultApp(session_file_path).then(([app, file]) => {
                 try {
                     app.launch([file], global.create_app_launch_context(DateUtils.get_current_time(), -1));
                 } catch (error) {
@@ -122,7 +123,7 @@ class SessionItemButtons extends GObject.Object {
         });
         deleteButton.connect('clicked', () => {
             // We just trash file to trash scan instead of delete in case still need it.
-            FileUtils.trashSession(this.sessionItem._filename);
+            this._fileUtils.trashSession(this.sessionItem._filename);
         });
 
     }
@@ -148,7 +149,7 @@ class SessionItemButtons extends GObject.Object {
     }
 
     _addViewButton() {
-        const [exists, sessionFilePath] = FileUtils.sessionExists(this.sessionItem._filename);
+        const [exists, sessionFilePath] = this._fileUtils.sessionExists(this.sessionItem._filename);
         return this._addTextButton('View', exists);
     }
 

--- a/ui/sessionItemButtons.js
+++ b/ui/sessionItemButtons.js
@@ -227,8 +227,8 @@ class SessionItemButtons extends GObject.Object {
     }
     
     _onClickRestore(button, event) {
-        Autoclose.sessionClosedByUser = false;
-        RestoreSession.restoringApps = new Map();
+        Autoclose.autocloseObject.sessionClosedByUser = false;
+        RestoreSession.restoreSessionObject.restoringApps = new Map();
         // Using _restoredApps to hold restored apps so we create new instance every time for now
         const _restoreSession = new RestoreSession.RestoreSession();
         _restoreSession.restoreSession(this.sessionItem._filename);

--- a/ui/uiHelper.js
+++ b/ui/uiHelper.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const { Meta } = imports.gi;
+import Meta from 'gi://Meta';
 
-function isDialog(metaWindow) {
+
+export function isDialog(metaWindow) {
     const dialogTypes = [
         // 3
         Meta.WindowType.DIALOG,
@@ -14,7 +15,7 @@ function isDialog(metaWindow) {
         metaWindow.get_transient_for() != null;
 }
 
-function ignoreWindows(metaWindow) {
+export function ignoreWindows(metaWindow) {
     if (isDialog(metaWindow)) {
         return true;
     }

--- a/utils/CommonError.js
+++ b/utils/CommonError.js
@@ -14,7 +14,7 @@
  * @param message 
  * @param options 
  */
-var CommonError = class extends Error{
+export const CommonError = class extends Error{
 
     constructor(message, options = {}) {
         if (!options.cause) {

--- a/utils/WindowPicker.js
+++ b/utils/WindowPicker.js
@@ -5,13 +5,18 @@
 
 'use strict';
 
-const {Clutter, GObject, Gio, GLib, Shell}  = imports.gi;
-const ByteArray    = imports.byteArray;
-const Main         = imports.ui.main;
-const LookingGlass = imports.ui.lookingGlass;
-const Me           = imports.misc.extensionUtils.getCurrentExtension();
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Shell from 'gi://Shell';
 
-const GnomeVersion = Me.imports.utils.gnomeVersion;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as LookingGlass from 'resource:///org/gnome/shell/ui/lookingGlass.js';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+import * as GnomeVersion from './gnomeVersion.js';
 
 
 // Based on the WindowPicker.js from Burn-My-Windows. 
@@ -26,12 +31,13 @@ const GnomeVersion = Me.imports.utils.gnomeVersion;
 // picking.                                                                             //
 //////////////////////////////////////////////////////////////////////////////////////////
 
-var WindowPickerServiceProvider = class WindowPickerServiceProvider {
+export const WindowPickerServiceProvider = class WindowPickerServiceProvider {
   // ------------------------------------------------------------------------- constructor
 
   constructor() {
-    const iFace = ByteArray.toString(
-      Me.dir.get_child('dbus-interfaces').get_child('org.gnome.Shell.Extensions.awsm.PickWindow.xml').load_contents(null)[1]);
+    let extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
+    const iFace = new TextDecoder().decode(
+      extensionObject.dir.get_child('dbus-interfaces').get_child('org.gnome.Shell.Extensions.awsm.PickWindow.xml').load_contents(null)[1]);
     this._dbus = Gio.DBusExportedObject.wrapJSObject(iFace, this);
   }
 
@@ -129,7 +135,7 @@ var WindowPickerServiceProvider = class WindowPickerServiceProvider {
   }
 };
 
-var MyInspector = GObject.registerClass({
+const MyInspector = GObject.registerClass({
   Signals: {
     'WindowPickCancelled': {}
   }

--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -15,6 +15,6 @@
  * 
  * @returns guint32 type timestamp, for example 75176468
  */
-var get_current_time = function() {
+export const get_current_time = function() {
     return global.get_current_time() || global.display.get_current_time_roundtrip();
 }

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -1,350 +1,367 @@
 'use strict';
 
-const { Gio, GLib } = imports.gi
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
-const Log = Me.imports.utils.log;
+import * as Log from './log.js';
 
-var default_sessionName = 'defaultSession';
-var data_dir = GLib.get_user_data_dir();
-var user_config = GLib.get_user_config_dir();
+let Extension;
+try {
+    let extensionObj = await import('resource:///org/gnome/shell/extensions/extension.js');
+    Extension = extensionObj.Extension;
+} catch (e) {
+    let extensionPrefsObj = await import('resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js');
+    Extension = extensionPrefsObj.ExtensionPreferences;
+}
+
+export const default_sessionName = 'defaultSession';
+export const data_dir = GLib.get_user_data_dir();
+export const user_config = GLib.get_user_config_dir();
 // This extension can restore `xsm`'s session file, 
 // but desktop_file_id is missing in that file, so can't move them. Will be fixed in the future.
-var config_path_base = GLib.build_filenamev([user_config, 'another-window-session-manager']);
+export const config_path_base = GLib.build_filenamev([user_config, 'another-window-session-manager']);
 // The session list
-var sessions_path = GLib.build_filenamev([config_path_base, 'sessions']);
-var sessions_backup_folder_name = 'backups';
+export const sessions_path = GLib.build_filenamev([config_path_base, 'sessions']);
+export const sessions_backup_folder_name = 'backups';
 const sessions_backup_path = GLib.build_filenamev([sessions_path, sessions_backup_folder_name]);
 
-var desktop_template_path = GLib.build_filenamev([Me.path, '/template/template.desktop']);
-var desktop_template_path_restore_at_autostart = GLib.build_filenamev([Me.path, '/template/_gnome-shell-extension-another-window-session-manager.desktop']);
-var desktop_template_path_restore_previous_at_autostart = GLib.build_filenamev([Me.path, '/template/_awsm-restore-previous-session.desktop']);
-var desktop_template_launch_app_shell_script = GLib.build_filenamev([Me.path, '/template/launch-app.sh']);
+export const desktop_file_store_path_base = GLib.build_filenamev([data_dir, '/applications']);
+export const desktop_file_store_path = `${desktop_file_store_path_base}/__another-window-session-manager`;
 
-var desktop_file_store_path_base = GLib.build_filenamev([data_dir, '/applications']);
-var desktop_file_store_path = `${desktop_file_store_path_base}/__another-window-session-manager`;
+export const recently_closed_session_name = 'Recently Closed Session';
+export const recently_closed_session_path = GLib.build_filenamev([sessions_path, recently_closed_session_name]);
+export const recently_closed_session_file = Gio.File.new_for_path(recently_closed_session_path);
 
-var recently_closed_session_name = 'Recently Closed Session';
-var recently_closed_session_path = GLib.build_filenamev([sessions_path, recently_closed_session_name]);
-var recently_closed_session_file = Gio.File.new_for_path(recently_closed_session_path);
+export const current_session_path = `${config_path_base}/currentSession`;
 
-var current_session_path = `${config_path_base}/currentSession`;
+export const current_session_summary_name = 'summary.json';
+export const current_session_summary_path = GLib.build_filenamev([current_session_path, 'summary.json']);
 
-var current_session_summary_name = 'summary.json';
-var current_session_summary_path = GLib.build_filenamev([current_session_path, 'summary.json']);
+export const autostart_restore_desktop_file_path = GLib.build_filenamev([user_config, '/autostart/_gnome-shell-extension-another-window-session-manager.desktop']);
+export const autostart_restore_previous_desktop_file_path = GLib.build_filenamev([user_config, '/autostart/_awsm-restore-previous-session.desktop']);
 
-var autostart_restore_desktop_file_path = GLib.build_filenamev([user_config, '/autostart/_gnome-shell-extension-another-window-session-manager.desktop']);
-var autostart_restore_previous_desktop_file_path = GLib.build_filenamev([user_config, '/autostart/_awsm-restore-previous-session.desktop']);
+export const system_udev_rules_path_ydotool_uinput_rules = '/etc/udev/rules.d/60-awsm-ydotool-uinput.rules';
 
-var desktop_template_path_ydotool_uinput_rules = GLib.build_filenamev([Me.path, '/template/60-awsm-ydotool-uinput.rules']);
-var system_udev_rules_path_ydotool_uinput_rules = '/etc/udev/rules.d/60-awsm-ydotool-uinput.rules';
 
-async function loadSummary() {
-    try {
-        return await loadFile(current_session_summary_path);   
-    } catch (error) {
-        Log.Log.getDefault().error(error);
+export const FileUtils = class FileUtils {
+    
+    constructor() {
+        const extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
+        // this.settings = extensionObject.getSettings('org.gnome.shell.extensions.another-window-session-manager');
+        this.desktop_template_path = GLib.build_filenamev([extensionObject.path, '/template/template.desktop']);
+        this.desktop_template_path_restore_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_gnome-shell-extension-another-window-session-manager.desktop']);
+        this.desktop_template_path_restore_previous_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_awsm-restore-previous-session.desktop']);
+        this.desktop_template_launch_app_shell_script = GLib.build_filenamev([extensionObject.path, '/template/launch-app.sh']);
+        this.desktop_template_path_ydotool_uinput_rules = GLib.build_filenamev([extensionObject.path, '/template/60-awsm-ydotool-uinput.rules']);
     }
-}
 
-async function loadFile(path) {
-    try {
-        return new Promise((resolve, reject) => {
-            const file = Gio.File.new_for_path(path);
-            file.load_contents_async(
-            null, 
-            (file, asyncResult) => {
-                try {
-                    const [success, contents, _] = file.load_contents_finish(asyncResult);
-                    resolve([getJsonObj(contents), path]);
-                } catch (error) {
-                    Log.Log.getDefault().error(error);
-                    reject(error);
-                }
+    async loadSummary() {
+        try {
+            return await this.loadFile(current_session_summary_path);   
+        } catch (error) {
+            Log.Log.getDefault().error(error);
+        }
+    }
+
+    async loadFile(path) {
+        try {
+            return new Promise((resolve, reject) => {
+                const file = Gio.File.new_for_path(path);
+                file.load_contents_async(
+                null, 
+                (file, asyncResult) => {
+                    try {
+                        const [success, contents, _] = file.load_contents_finish(asyncResult);
+                        resolve([getJsonObj(contents), path]);
+                    } catch (error) {
+                        Log.Log.getDefault().error(error);
+                        reject(error);
+                    }
+                });
             });
-        });
-    } catch (error) {
-        Log.Log.getDefault().error(error);
-    }
-}
-
-/**
- * Get the absolute session path which contains sessions, 
- * it's `~/.config/another-window-session-manager` by default.
- * 
- * @param {string} baseDir base directory, `~/.config/another-window-session-manager/sessions` by default
- * @returns {string} the absolute session path which contains sessions
- */
-function get_sessions_path(baseDir = null) {
-    if (baseDir) {
-        return baseDir;
-    } else {
-        return sessions_path;
-    }
-}
-
-function get_sessions_backups_path() {
-    return sessions_backup_path;
-}
-
-function getJsonObj(contents) {
-    let session_config;
-    // Fix Gnome 3 crash due to: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array).
-    if (contents instanceof Uint8Array) {
-        const contentsConverted = imports.byteArray.toString(contents);
-        session_config = JSON.parse(contentsConverted);
-    } else {
-        // Unreachable code
-        session_config = JSON.parse(contents);
-    }
-    return session_config;
-}
-
-async function listAllSessions(sessionPath, recursion, callback) {
-    try {
-        if (!sessionPath) {
-            sessionPath = get_sessions_path();
+        } catch (error) {
+            Log.Log.getDefault().error(error);
         }
-        if (!GLib.file_test(sessionPath, GLib.FileTest.EXISTS)) {
-            Log.Log.getDefault().warn(`${sessionPath} not exist`);
-            return;
+    }
+
+    /**
+     * Get the absolute session path which contains sessions, 
+     * it's `~/.config/another-window-session-manager` by default.
+     * 
+     * @param {string} baseDir base directory, `~/.config/another-window-session-manager/sessions` by default
+     * @returns {string} the absolute session path which contains sessions
+     */
+    get_sessions_path(baseDir = null) {
+        if (baseDir) {
+            return baseDir;
+        } else {
+            return sessions_path;
         }
-    
-        Log.Log.getDefault().debug(`Scanning ${sessionPath}`);
-    
-        const sessionPathFile = Gio.File.new_for_path(sessionPath);
-        let fileEnumerator = await new Promise((resolve, reject) => {
-            sessionPathFile.enumerate_children_async(
-                [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
-                Gio.FILE_ATTRIBUTE_STANDARD_TYPE,
-                Gio.FILE_ATTRIBUTE_TIME_MODIFIED,
-                Gio.FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE].join(','),
+    }
+
+    get_sessions_backups_path() {
+        return sessions_backup_path;
+    }
+
+    getJsonObj(contents) {
+        let session_config;
+        // Fix Gnome 3 crash due to: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call new TextDecoder().decode(array).
+        if (contents instanceof Uint8Array) {
+            const contentsConverted = new TextDecoder().decode(contents);
+            session_config = JSON.parse(contentsConverted);
+        } else {
+            // Unreachable code
+            session_config = JSON.parse(contents);
+        }
+        return session_config;
+    }
+
+    async listAllSessions(sessionPath, recursion, callback) {
+        try {
+            if (!sessionPath) {
+                sessionPath = this.get_sessions_path();
+            }
+            if (!GLib.file_test(sessionPath, GLib.FileTest.EXISTS)) {
+                Log.Log.getDefault().warn(`${sessionPath} not exist`);
+                return;
+            }
+        
+            Log.Log.getDefault().debug(`Scanning ${sessionPath}`);
+        
+            const sessionPathFile = Gio.File.new_for_path(sessionPath);
+            let fileEnumerator = await new Promise((resolve, reject) => {
+                sessionPathFile.enumerate_children_async(
+                    [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+                    Gio.FILE_ATTRIBUTE_STANDARD_TYPE,
+                    Gio.FILE_ATTRIBUTE_TIME_MODIFIED,
+                    Gio.FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE].join(','),
+                    Gio.FileQueryInfoFlags.NONE,
+                    GLib.PRIORITY_DEFAULT,
+                    null,
+                    (file, asyncResult) => {
+                        try {
+                            resolve(file.enumerate_children_finish(asyncResult));
+                        } catch (e) {
+                            Log.Log.getDefault().error(e, `Failed to list directory ${sessionPath}`);
+                            reject(e);
+                        }
+                    });
+            });
+
+            const nextFilesFunc = async () => {
+                return new Promise((resolve, reject) => {
+                    fileEnumerator.next_files_async(
+                        // num_files. Just set a random value, because I don't know which value is better yet
+                        10,
+                        GLib.PRIORITY_DEFAULT,
+                        null,
+                        (iter, asyncResult) => {
+                            try {
+                                resolve(iter.next_files_finish(asyncResult));
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }
+                    );
+                });
+            };
+
+            let infos = await nextFilesFunc();
+            while (infos && infos.length) {
+                for (const info of infos) {
+                    const file = fileEnumerator.get_child(info);
+                    if (recursion && info.get_file_type() === Gio.FileType.DIRECTORY) {
+                        await this.listAllSessions(file.get_path(), recursion, callback);
+                    }
+
+                    if (callback) {
+                        callback(file, info);
+                    }
+                }
+
+                infos = await nextFilesFunc();
+            }
+        } catch (e) {
+            Log.Log.getDefault().error(e);
+        }
+    }
+
+    sessionExists(sessionName, baseDir = null) {
+        const sessionsPath = this.get_sessions_path(baseDir);
+        const sessionFilePath = GLib.build_filenamev([sessionsPath, sessionName]);
+        if (GLib.file_test(sessionFilePath, GLib.FileTest.EXISTS)) {
+            return [true, sessionFilePath];
+        }
+        return [false];
+    }
+
+    /**
+     * Remove files. And also remove its parent if it's empty.
+     * 
+     * @param {String} path         The path of a file or a directory
+     */
+    removeFileAndParent(path) {
+        if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
+            throw new Error(`Cannot remove '${path}': No such file or directory`);
+        }
+
+        const file = Gio.File.new_for_path(path);
+        try {
+            const info = file.query_info(
+                [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
                 Gio.FileQueryInfoFlags.NONE,
+                null);
+
+            const fileType = info.get_file_type();
+            const isDir = fileType === Gio.FileType.DIRECTORY;
+            
+            file.delete(null);
+            Log.Log.getDefault().debug(`Removed ${isDir ? 'directory' : ''} ${path}`);
+
+            const parent = file.get_parent();
+            if (parent && isEmpty(parent)) {
+                parent.delete(null);
+                Log.Log.getDefault().debug(`Removed directory ${parent.get_path()}`);
+            }
+        
+        } catch (e) {
+            Log.Log.getDefault().error(e);
+        }
+    }
+
+    isEmpty(directory) {
+        const fileEnumerator = directory.enumerate_children(
+            [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+            Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
+            Gio.FileQueryInfoFlags.NONE, 
+            null);
+        return !fileEnumerator.next_file(null);
+    }
+
+    /**
+     * Remove files or directories
+     * 
+     * @param {String} path         The path of a file or a directory
+     * @param {Boolean} recursively true if remove all files or directories in `path`
+     */
+    removeFile(path, recursively = false) {
+        if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
+            throw new Error(`Cannot remove '${path}': No such file or directory`);
+        }
+
+        const file = Gio.File.new_for_path(path);
+        try {
+            const info = file.query_info(
+                [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
+                Gio.FileQueryInfoFlags.NONE,
+                null);
+
+            const fileType = info.get_file_type();
+            if (fileType === Gio.FileType.DIRECTORY) {
+                if (!recursively) {
+                    throw new Error(`Cannot remove '${path}': Is a directory`);
+                }
+                const fileEnumerator = file.enumerate_children(
+                    [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+                    Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
+                    Gio.FileQueryInfoFlags.NONE, 
+                    null);
+                
+                let fileInfo = null;
+                while (fileInfo = fileEnumerator.next_file(null)) {
+                    const childFile = fileEnumerator.get_child(fileInfo);
+                    if (info.get_file_type() === Gio.FileType.DIRECTORY) {
+                        this.removeFile(childFile.get_path(), recursively);
+                    }
+                }
+
+                file.delete(null);
+                Log.Log.getDefault().debug(`Removed directory ${path}`);
+            } else {
+                file.delete(null);
+                Log.Log.getDefault().debug(`Removed ${path}`);
+            }
+        } catch (e) {
+            Log.Log.getDefault().error(e);
+        }
+    }
+
+    trashSession(sessionName) {
+        const [exists, sessionFilePath] = this.sessionExists(sessionName);
+        if (!exists) {
+            return true;
+        }
+
+        let trashed = false;
+        try {
+            const sessionPathFile = Gio.File.new_for_path(sessionFilePath);
+            trashed = sessionPathFile.trash(null);
+            if (!trashed) {
+                Log.Log.getDefault().error(new Error(`Failed to trash file ${sessionFilePath}. Reason: Unknown.`));
+            }
+            return trashed;
+        } catch (e) {
+            Log.Log.getDefault().error(e, `Failed to trash file ${sessionFilePath}`);
+            return false;
+        }
+    }
+
+    isDirectory(sessionName) {
+        const sessionFilePath = GLib.build_filenamev([sessions_path, sessionName]);
+        if (GLib.file_test(sessionFilePath, GLib.FileTest.IS_DIR)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    loadAutostartDesktopTemplate() {
+        return this.loadTemplate(this.desktop_template_path_restore_at_autostart);
+    }
+
+    loadDesktopTemplate(cancellable = null) {
+        return this.loadTemplate(this.desktop_template_path, cancellable);
+    }
+
+    loadTemplate(path, cancellable = null) {
+        const desktop_template_file = Gio.File.new_for_path(path);
+        let [success, contents] = desktop_template_file.load_contents(cancellable);
+        if (success) {
+            if (contents instanceof Uint8Array) {
+                return new TextDecoder().decode(contents);
+            } else {
+                // Unreachable code
+                return contents;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Find the default app to open session file
+     * 
+     * @param {string} filePath 
+     */
+    findDefaultApp(filePath) {
+        const session_file = Gio.File.new_for_path(filePath);
+        return new Promise((resolve, reject) => {
+            session_file.query_default_handler_async(
                 GLib.PRIORITY_DEFAULT,
                 null,
                 (file, asyncResult) => {
                     try {
-                        resolve(file.enumerate_children_finish(asyncResult));
-                    } catch (e) {
-                        Log.Log.getDefault().error(e, `Failed to list directory ${sessionPath}`);
-                        reject(e);
+                        const app = session_file.query_default_handler_finish(asyncResult);
+                        if (app) {
+                            resolve([app, session_file]);
+                        } else {
+                            reject(new Error(`Cannot find the default application to ${filePath}`));
+                        }   
+                    } catch (error) {
+                        reject(error);
                     }
                 });
-        });
-
-        const nextFilesFunc = async () => {
-            return new Promise((resolve, reject) => {
-                fileEnumerator.next_files_async(
-                    // num_files. Just set a random value, because I don't know which value is better yet
-                    10,
-                    GLib.PRIORITY_DEFAULT,
-                    null,
-                    (iter, asyncResult) => {
-                        try {
-                            resolve(iter.next_files_finish(asyncResult));
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-                );
-            });
-        };
-
-        let infos = await nextFilesFunc();
-        while (infos && infos.length) {
-            for (const info of infos) {
-                const file = fileEnumerator.get_child(info);
-                if (recursion && info.get_file_type() === Gio.FileType.DIRECTORY) {
-                    await listAllSessions(file.get_path(), recursion, callback);
-                }
-
-                if (callback) {
-                    callback(file, info);
-                }
-            }
-
-            infos = await nextFilesFunc();
-        }
-    } catch (e) {
-        Log.Log.getDefault().error(e);
-    }
-}
-
-function sessionExists(sessionName, baseDir = null) {
-    const sessionsPath = get_sessions_path(baseDir);
-    const sessionFilePath = GLib.build_filenamev([sessionsPath, sessionName]);
-    if (GLib.file_test(sessionFilePath, GLib.FileTest.EXISTS)) {
-        return [true, sessionFilePath];
-    }
-    return [false];
-}
-
-/**
- * Remove files. And also remove its parent if it's empty.
- * 
- * @param {String} path         The path of a file or a directory
- */
- function removeFileAndParent(path) {
-    if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
-        throw new Error(`Cannot remove '${path}': No such file or directory`);
+        });    
     }
 
-    const file = Gio.File.new_for_path(path);
-    try {
-        const info = file.query_info(
-            [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
-            Gio.FileQueryInfoFlags.NONE,
-            null);
-
-        const fileType = info.get_file_type();
-        const isDir = fileType === Gio.FileType.DIRECTORY;
-        
-        file.delete(null);
-        Log.Log.getDefault().debug(`Removed ${isDir ? 'directory' : ''} ${path}`);
-
-        const parent = file.get_parent();
-        if (parent && isEmpty(parent)) {
-            parent.delete(null);
-            Log.Log.getDefault().debug(`Removed directory ${parent.get_path()}`);
-        }
-    
-    } catch (e) {
-        Log.Log.getDefault().error(e);
-    }
-}
-
-function isEmpty(directory) {
-    const fileEnumerator = directory.enumerate_children(
-        [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
-        Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
-        Gio.FileQueryInfoFlags.NONE, 
-        null);
-    return !fileEnumerator.next_file(null);
-}
-
-/**
- * Remove files or directories
- * 
- * @param {String} path         The path of a file or a directory
- * @param {Boolean} recursively true if remove all files or directories in `path`
- */
- function removeFile(path, recursively = false) {
-    if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
-        throw new Error(`Cannot remove '${path}': No such file or directory`);
-    }
-
-    const file = Gio.File.new_for_path(path);
-    try {
-        const info = file.query_info(
-            [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
-            Gio.FileQueryInfoFlags.NONE,
-            null);
-
-        const fileType = info.get_file_type();
-        if (fileType === Gio.FileType.DIRECTORY) {
-            if (!recursively) {
-                throw new Error(`Cannot remove '${path}': Is a directory`);
-            }
-            const fileEnumerator = file.enumerate_children(
-                [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
-                Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
-                Gio.FileQueryInfoFlags.NONE, 
-                null);
-            
-            let fileInfo = null;
-            while (fileInfo = fileEnumerator.next_file(null)) {
-                const childFile = fileEnumerator.get_child(fileInfo);
-                if (info.get_file_type() === Gio.FileType.DIRECTORY) {
-                    removeFile(childFile.get_path(), recursively);
-                }
-            }
-
-            file.delete(null);
-            Log.Log.getDefault().debug(`Removed directory ${path}`);
-        } else {
-            file.delete(null);
-            Log.Log.getDefault().debug(`Removed ${path}`);
-        }
-    } catch (e) {
-        Log.Log.getDefault().error(e);
-    }
-}
-
-function trashSession(sessionName) {
-    const [exists, sessionFilePath] = sessionExists(sessionName);
-    if (!exists) {
-        return true;
-    }
-
-    let trashed = false;
-    try {
-        const sessionPathFile = Gio.File.new_for_path(sessionFilePath);
-        trashed = sessionPathFile.trash(null);
-        if (!trashed) {
-            Log.Log.getDefault().error(new Error(`Failed to trash file ${sessionFilePath}. Reason: Unknown.`));
-        }
-        return trashed;
-    } catch (e) {
-        Log.Log.getDefault().error(e, `Failed to trash file ${sessionFilePath}`);
-        return false;
-    }
-}
-
-function isDirectory(sessionName) {
-    const sessionFilePath = GLib.build_filenamev([sessions_path, sessionName]);
-    if (GLib.file_test(sessionFilePath, GLib.FileTest.IS_DIR)) {
-        return true;
-    }
-
-    return false;
-}
-
-function loadAutostartDesktopTemplate() {
-    return loadTemplate(desktop_template_path_restore_at_autostart);
-}
-
-function loadDesktopTemplate(cancellable = null) {
-    return loadTemplate(desktop_template_path, cancellable);
-}
-
-function loadTemplate(path, cancellable = null) {
-    const desktop_template_file = Gio.File.new_for_path(path);
-    let [success, contents] = desktop_template_file.load_contents(cancellable);
-    if (success) {
-        if (contents instanceof Uint8Array) {
-            return imports.byteArray.toString(contents);
-        } else {
-            // Unreachable code
-            return contents;
-        }
-    }
-
-    return '';
-}
-
-/**
- * Find the default app to open session file
- * 
- * @param {string} filePath 
- */
-function findDefaultApp(filePath) {
-    const session_file = Gio.File.new_for_path(filePath);
-    return new Promise((resolve, reject) => {
-        session_file.query_default_handler_async(
-            GLib.PRIORITY_DEFAULT,
-            null,
-            (file, asyncResult) => {
-                try {
-                    const app = session_file.query_default_handler_finish(asyncResult);
-                    if (app) {
-                        resolve([app, session_file]);
-                    } else {
-                        reject(new Error(`Cannot find the default application to ${filePath}`));
-                    }   
-                } catch (error) {
-                    reject(error);
-                }
-            });
-    });    
 }

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -47,7 +47,6 @@ export const FileUtils = class FileUtils {
     
     constructor() {
         const extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
-        // this.settings = extensionObject.getSettings('org.gnome.shell.extensions.another-window-session-manager');
         this.desktop_template_path = GLib.build_filenamev([extensionObject.path, '/template/template.desktop']);
         this.desktop_template_path_restore_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_gnome-shell-extension-another-window-session-manager.desktop']);
         this.desktop_template_path_restore_previous_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_awsm-restore-previous-session.desktop']);

--- a/utils/fileUtils.js
+++ b/utils/fileUtils.js
@@ -5,25 +5,21 @@ import GLib from 'gi://GLib';
 
 import * as Log from './log.js';
 
-let Extension;
-try {
-    let extensionObj = await import('resource:///org/gnome/shell/extensions/extension.js');
-    Extension = extensionObj.Extension;
-} catch (e) {
-    let extensionPrefsObj = await import('resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js');
-    Extension = extensionPrefsObj.ExtensionPreferences;
-}
-
 export const default_sessionName = 'defaultSession';
 export const data_dir = GLib.get_user_data_dir();
 export const user_config = GLib.get_user_config_dir();
-// This extension can restore `xsm`'s session file, 
+// This extension can restore `xsm`'s session file,
 // but desktop_file_id is missing in that file, so can't move them. Will be fixed in the future.
 export const config_path_base = GLib.build_filenamev([user_config, 'another-window-session-manager']);
 // The session list
 export const sessions_path = GLib.build_filenamev([config_path_base, 'sessions']);
 export const sessions_backup_folder_name = 'backups';
 const sessions_backup_path = GLib.build_filenamev([sessions_path, sessions_backup_folder_name]);
+
+export let desktop_template_path;
+export let desktop_template_path_restore_at_autostart;
+export let desktop_template_path_restore_previous_at_autostart;
+export let desktop_template_launch_app_shell_script;
 
 export const desktop_file_store_path_base = GLib.build_filenamev([data_dir, '/applications']);
 export const desktop_file_store_path = `${desktop_file_store_path_base}/__another-window-session-manager`;
@@ -40,34 +36,34 @@ export const current_session_summary_path = GLib.build_filenamev([current_sessio
 export const autostart_restore_desktop_file_path = GLib.build_filenamev([user_config, '/autostart/_gnome-shell-extension-another-window-session-manager.desktop']);
 export const autostart_restore_previous_desktop_file_path = GLib.build_filenamev([user_config, '/autostart/_awsm-restore-previous-session.desktop']);
 
+export let desktop_template_path_ydotool_uinput_rules;
 export const system_udev_rules_path_ydotool_uinput_rules = '/etc/udev/rules.d/60-awsm-ydotool-uinput.rules';
 
+// Some constants rely on extension metadata,
+// we put them all here and initialize them from extension.js 
+export function init(extensionObject) {
+    desktop_template_path = GLib.build_filenamev([extensionObject.path, '/template/template.desktop']);
+    desktop_template_path_restore_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_gnome-shell-extension-another-window-session-manager.desktop']);
+    desktop_template_path_restore_previous_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_awsm-restore-previous-session.desktop']);
+    desktop_template_launch_app_shell_script = GLib.build_filenamev([extensionObject.path, '/template/launch-app.sh']);
+    desktop_template_path_ydotool_uinput_rules = GLib.build_filenamev([extensionObject.path, '/template/60-awsm-ydotool-uinput.rules']);
 
-export const FileUtils = class FileUtils {
-    
-    constructor() {
-        const extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
-        this.desktop_template_path = GLib.build_filenamev([extensionObject.path, '/template/template.desktop']);
-        this.desktop_template_path_restore_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_gnome-shell-extension-another-window-session-manager.desktop']);
-        this.desktop_template_path_restore_previous_at_autostart = GLib.build_filenamev([extensionObject.path, '/template/_awsm-restore-previous-session.desktop']);
-        this.desktop_template_launch_app_shell_script = GLib.build_filenamev([extensionObject.path, '/template/launch-app.sh']);
-        this.desktop_template_path_ydotool_uinput_rules = GLib.build_filenamev([extensionObject.path, '/template/60-awsm-ydotool-uinput.rules']);
+}
+
+export async function loadSummary() {
+    try {
+        return await loadFile(current_session_summary_path);
+    } catch (error) {
+        Log.Log.getDefault().error(error);
     }
+}
 
-    async loadSummary() {
-        try {
-            return await this.loadFile(current_session_summary_path);   
-        } catch (error) {
-            Log.Log.getDefault().error(error);
-        }
-    }
-
-    async loadFile(path) {
-        try {
-            return new Promise((resolve, reject) => {
-                const file = Gio.File.new_for_path(path);
-                file.load_contents_async(
-                null, 
+export async function loadFile(path) {
+    try {
+        return new Promise((resolve, reject) => {
+            const file = Gio.File.new_for_path(path);
+            file.load_contents_async(
+                null,
                 (file, asyncResult) => {
                     try {
                         const [success, contents, _] = file.load_contents_finish(asyncResult);
@@ -77,290 +73,288 @@ export const FileUtils = class FileUtils {
                         reject(error);
                     }
                 });
-            });
-        } catch (error) {
-            Log.Log.getDefault().error(error);
-        }
+        });
+    } catch (error) {
+        Log.Log.getDefault().error(error);
     }
+}
 
-    /**
-     * Get the absolute session path which contains sessions, 
-     * it's `~/.config/another-window-session-manager` by default.
-     * 
-     * @param {string} baseDir base directory, `~/.config/another-window-session-manager/sessions` by default
-     * @returns {string} the absolute session path which contains sessions
-     */
-    get_sessions_path(baseDir = null) {
-        if (baseDir) {
-            return baseDir;
-        } else {
-            return sessions_path;
-        }
+/**
+ * Get the absolute session path which contains sessions,
+ * it's `~/.config/another-window-session-manager` by default.
+ *
+ * @param {string} baseDir base directory, `~/.config/another-window-session-manager/sessions` by default
+ * @returns {string} the absolute session path which contains sessions
+ */
+export function get_sessions_path(baseDir = null) {
+    if (baseDir) {
+        return baseDir;
+    } else {
+        return sessions_path;
     }
+}
 
-    get_sessions_backups_path() {
-        return sessions_backup_path;
-    }
+export function get_sessions_backups_path() {
+    return sessions_backup_path;
+}
 
-    getJsonObj(contents) {
-        let session_config;
+export function getJsonObj(contents) {
+    let session_config;
         // Fix Gnome 3 crash due to: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call new TextDecoder().decode(array).
-        if (contents instanceof Uint8Array) {
-            const contentsConverted = new TextDecoder().decode(contents);
-            session_config = JSON.parse(contentsConverted);
-        } else {
-            // Unreachable code
-            session_config = JSON.parse(contents);
-        }
-        return session_config;
+    if (contents instanceof Uint8Array) {
+        const contentsConverted = new TextDecoder().decode(contents);
+        session_config = JSON.parse(contentsConverted);
+    } else {
+        // Unreachable code
+        session_config = JSON.parse(contents);
     }
+    return session_config;
+}
 
-    async listAllSessions(sessionPath, recursion, callback) {
-        try {
-            if (!sessionPath) {
-                sessionPath = this.get_sessions_path();
-            }
-            if (!GLib.file_test(sessionPath, GLib.FileTest.EXISTS)) {
-                Log.Log.getDefault().warn(`${sessionPath} not exist`);
-                return;
-            }
-        
-            Log.Log.getDefault().debug(`Scanning ${sessionPath}`);
-        
-            const sessionPathFile = Gio.File.new_for_path(sessionPath);
-            let fileEnumerator = await new Promise((resolve, reject) => {
-                sessionPathFile.enumerate_children_async(
-                    [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+export async function listAllSessions(sessionPath, recursion, callback) {
+    try {
+        if (!sessionPath) {
+            sessionPath = get_sessions_path();
+        }
+        if (!GLib.file_test(sessionPath, GLib.FileTest.EXISTS)) {
+            Log.Log.getDefault().warn(`${sessionPath} not exist`);
+            return;
+        }
+
+        Log.Log.getDefault().debug(`Scanning ${sessionPath}`);
+
+        const sessionPathFile = Gio.File.new_for_path(sessionPath);
+        let fileEnumerator = await new Promise((resolve, reject) => {
+            sessionPathFile.enumerate_children_async(
+                [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
                     Gio.FILE_ATTRIBUTE_STANDARD_TYPE,
                     Gio.FILE_ATTRIBUTE_TIME_MODIFIED,
                     Gio.FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE].join(','),
-                    Gio.FileQueryInfoFlags.NONE,
-                    GLib.PRIORITY_DEFAULT,
-                    null,
-                    (file, asyncResult) => {
-                        try {
-                            resolve(file.enumerate_children_finish(asyncResult));
-                        } catch (e) {
-                            Log.Log.getDefault().error(e, `Failed to list directory ${sessionPath}`);
-                            reject(e);
-                        }
-                    });
-            });
-
-            const nextFilesFunc = async () => {
-                return new Promise((resolve, reject) => {
-                    fileEnumerator.next_files_async(
-                        // num_files. Just set a random value, because I don't know which value is better yet
-                        10,
-                        GLib.PRIORITY_DEFAULT,
-                        null,
-                        (iter, asyncResult) => {
-                            try {
-                                resolve(iter.next_files_finish(asyncResult));
-                            } catch (e) {
-                                reject(e);
-                            }
-                        }
-                    );
-                });
-            };
-
-            let infos = await nextFilesFunc();
-            while (infos && infos.length) {
-                for (const info of infos) {
-                    const file = fileEnumerator.get_child(info);
-                    if (recursion && info.get_file_type() === Gio.FileType.DIRECTORY) {
-                        await this.listAllSessions(file.get_path(), recursion, callback);
-                    }
-
-                    if (callback) {
-                        callback(file, info);
-                    }
-                }
-
-                infos = await nextFilesFunc();
-            }
-        } catch (e) {
-            Log.Log.getDefault().error(e);
-        }
-    }
-
-    sessionExists(sessionName, baseDir = null) {
-        const sessionsPath = this.get_sessions_path(baseDir);
-        const sessionFilePath = GLib.build_filenamev([sessionsPath, sessionName]);
-        if (GLib.file_test(sessionFilePath, GLib.FileTest.EXISTS)) {
-            return [true, sessionFilePath];
-        }
-        return [false];
-    }
-
-    /**
-     * Remove files. And also remove its parent if it's empty.
-     * 
-     * @param {String} path         The path of a file or a directory
-     */
-    removeFileAndParent(path) {
-        if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
-            throw new Error(`Cannot remove '${path}': No such file or directory`);
-        }
-
-        const file = Gio.File.new_for_path(path);
-        try {
-            const info = file.query_info(
-                [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
                 Gio.FileQueryInfoFlags.NONE,
-                null);
-
-            const fileType = info.get_file_type();
-            const isDir = fileType === Gio.FileType.DIRECTORY;
-            
-            file.delete(null);
-            Log.Log.getDefault().debug(`Removed ${isDir ? 'directory' : ''} ${path}`);
-
-            const parent = file.get_parent();
-            if (parent && isEmpty(parent)) {
-                parent.delete(null);
-                Log.Log.getDefault().debug(`Removed directory ${parent.get_path()}`);
-            }
-        
-        } catch (e) {
-            Log.Log.getDefault().error(e);
-        }
-    }
-
-    isEmpty(directory) {
-        const fileEnumerator = directory.enumerate_children(
-            [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
-            Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
-            Gio.FileQueryInfoFlags.NONE, 
-            null);
-        return !fileEnumerator.next_file(null);
-    }
-
-    /**
-     * Remove files or directories
-     * 
-     * @param {String} path         The path of a file or a directory
-     * @param {Boolean} recursively true if remove all files or directories in `path`
-     */
-    removeFile(path, recursively = false) {
-        if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
-            throw new Error(`Cannot remove '${path}': No such file or directory`);
-        }
-
-        const file = Gio.File.new_for_path(path);
-        try {
-            const info = file.query_info(
-                [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
-                Gio.FileQueryInfoFlags.NONE,
-                null);
-
-            const fileType = info.get_file_type();
-            if (fileType === Gio.FileType.DIRECTORY) {
-                if (!recursively) {
-                    throw new Error(`Cannot remove '${path}': Is a directory`);
-                }
-                const fileEnumerator = file.enumerate_children(
-                    [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
-                    Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
-                    Gio.FileQueryInfoFlags.NONE, 
-                    null);
-                
-                let fileInfo = null;
-                while (fileInfo = fileEnumerator.next_file(null)) {
-                    const childFile = fileEnumerator.get_child(fileInfo);
-                    if (info.get_file_type() === Gio.FileType.DIRECTORY) {
-                        this.removeFile(childFile.get_path(), recursively);
-                    }
-                }
-
-                file.delete(null);
-                Log.Log.getDefault().debug(`Removed directory ${path}`);
-            } else {
-                file.delete(null);
-                Log.Log.getDefault().debug(`Removed ${path}`);
-            }
-        } catch (e) {
-            Log.Log.getDefault().error(e);
-        }
-    }
-
-    trashSession(sessionName) {
-        const [exists, sessionFilePath] = this.sessionExists(sessionName);
-        if (!exists) {
-            return true;
-        }
-
-        let trashed = false;
-        try {
-            const sessionPathFile = Gio.File.new_for_path(sessionFilePath);
-            trashed = sessionPathFile.trash(null);
-            if (!trashed) {
-                Log.Log.getDefault().error(new Error(`Failed to trash file ${sessionFilePath}. Reason: Unknown.`));
-            }
-            return trashed;
-        } catch (e) {
-            Log.Log.getDefault().error(e, `Failed to trash file ${sessionFilePath}`);
-            return false;
-        }
-    }
-
-    isDirectory(sessionName) {
-        const sessionFilePath = GLib.build_filenamev([sessions_path, sessionName]);
-        if (GLib.file_test(sessionFilePath, GLib.FileTest.IS_DIR)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    loadAutostartDesktopTemplate() {
-        return this.loadTemplate(this.desktop_template_path_restore_at_autostart);
-    }
-
-    loadDesktopTemplate(cancellable = null) {
-        return this.loadTemplate(this.desktop_template_path, cancellable);
-    }
-
-    loadTemplate(path, cancellable = null) {
-        const desktop_template_file = Gio.File.new_for_path(path);
-        let [success, contents] = desktop_template_file.load_contents(cancellable);
-        if (success) {
-            if (contents instanceof Uint8Array) {
-                return new TextDecoder().decode(contents);
-            } else {
-                // Unreachable code
-                return contents;
-            }
-        }
-
-        return '';
-    }
-
-    /**
-     * Find the default app to open session file
-     * 
-     * @param {string} filePath 
-     */
-    findDefaultApp(filePath) {
-        const session_file = Gio.File.new_for_path(filePath);
-        return new Promise((resolve, reject) => {
-            session_file.query_default_handler_async(
                 GLib.PRIORITY_DEFAULT,
                 null,
                 (file, asyncResult) => {
                     try {
-                        const app = session_file.query_default_handler_finish(asyncResult);
-                        if (app) {
-                            resolve([app, session_file]);
-                        } else {
-                            reject(new Error(`Cannot find the default application to ${filePath}`));
-                        }   
-                    } catch (error) {
-                        reject(error);
+                        resolve(file.enumerate_children_finish(asyncResult));
+                    } catch (e) {
+                        Log.Log.getDefault().error(e, `Failed to list directory ${sessionPath}`);
+                        reject(e);
                     }
                 });
-        });    
+        });
+
+        const nextFilesFunc = async () => {
+            return new Promise((resolve, reject) => {
+                fileEnumerator.next_files_async(
+                    // num_files. Just set a random value, because I don't know which value is better yet
+                    10,
+                    GLib.PRIORITY_DEFAULT,
+                    null,
+                    (iter, asyncResult) => {
+                        try {
+                            resolve(iter.next_files_finish(asyncResult));
+                        } catch (e) {
+                            reject(e);
+                        }
+                    }
+                );
+            });
+        };
+
+        let infos = await nextFilesFunc();
+        while (infos && infos.length) {
+            for (const info of infos) {
+                const file = fileEnumerator.get_child(info);
+                if (recursion && info.get_file_type() === Gio.FileType.DIRECTORY) {
+                    await listAllSessions(file.get_path(), recursion, callback);
+                }
+
+                if (callback) {
+                    callback(file, info);
+                }
+            }
+
+            infos = await nextFilesFunc();
+        }
+    } catch (e) {
+        Log.Log.getDefault().error(e);
+    }
+}
+
+export function sessionExists(sessionName, baseDir = null) {
+    const sessionsPath = get_sessions_path(baseDir);
+    const sessionFilePath = GLib.build_filenamev([sessionsPath, sessionName]);
+    if (GLib.file_test(sessionFilePath, GLib.FileTest.EXISTS)) {
+        return [true, sessionFilePath];
+    }
+    return [false];
+}
+
+/**
+ * Remove files. And also remove its parent if it's empty.
+ *
+ * @param {String} path         The path of a file or a directory
+ */
+export function removeFileAndParent(path) {
+    if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
+        throw new Error(`Cannot remove '${path}': No such file or directory`);
     }
 
+    const file = Gio.File.new_for_path(path);
+    try {
+        const info = file.query_info(
+            [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
+            Gio.FileQueryInfoFlags.NONE,
+            null);
+
+        const fileType = info.get_file_type();
+        const isDir = fileType === Gio.FileType.DIRECTORY;
+
+        file.delete(null);
+        Log.Log.getDefault().debug(`Removed ${isDir ? 'directory' : ''} ${path}`);
+
+        const parent = file.get_parent();
+        if (parent && isEmpty(parent)) {
+            parent.delete(null);
+            Log.Log.getDefault().debug(`Removed directory ${parent.get_path()}`);
+        }
+
+    } catch (e) {
+        Log.Log.getDefault().error(e);
+    }
+}
+
+export function isEmpty(directory) {
+    const fileEnumerator = directory.enumerate_children(
+        [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+            Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
+        Gio.FileQueryInfoFlags.NONE,
+        null);
+    return !fileEnumerator.next_file(null);
+}
+
+/**
+ * Remove files or directories
+ *
+ * @param {String} path         The path of a file or a directory
+ * @param {Boolean} recursively true if remove all files or directories in `path`
+ */
+export function removeFile(path, recursively = false) {
+    if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
+        throw new Error(`Cannot remove '${path}': No such file or directory`);
+    }
+
+    const file = Gio.File.new_for_path(path);
+    try {
+        const info = file.query_info(
+            [Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
+            Gio.FileQueryInfoFlags.NONE,
+            null);
+
+        const fileType = info.get_file_type();
+        if (fileType === Gio.FileType.DIRECTORY) {
+            if (!recursively) {
+                throw new Error(`Cannot remove '${path}': Is a directory`);
+            }
+            const fileEnumerator = file.enumerate_children(
+                [Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+                    Gio.FILE_ATTRIBUTE_STANDARD_TYPE].join(','),
+                Gio.FileQueryInfoFlags.NONE,
+                null);
+
+            let fileInfo = null;
+            while (fileInfo = fileEnumerator.next_file(null)) {
+                const childFile = fileEnumerator.get_child(fileInfo);
+                if (info.get_file_type() === Gio.FileType.DIRECTORY) {
+                    removeFile(childFile.get_path(), recursively);
+                }
+            }
+
+            file.delete(null);
+            Log.Log.getDefault().debug(`Removed directory ${path}`);
+        } else {
+            file.delete(null);
+            Log.Log.getDefault().debug(`Removed ${path}`);
+        }
+    } catch (e) {
+        Log.Log.getDefault().error(e);
+    }
+}
+
+export function trashSession(sessionName) {
+    const [exists, sessionFilePath] = sessionExists(sessionName);
+    if (!exists) {
+        return true;
+    }
+
+    let trashed = false;
+    try {
+        const sessionPathFile = Gio.File.new_for_path(sessionFilePath);
+        trashed = sessionPathFile.trash(null);
+        if (!trashed) {
+            Log.Log.getDefault().error(new Error(`Failed to trash file ${sessionFilePath}. Reason: Unknown.`));
+        }
+        return trashed;
+    } catch (e) {
+        Log.Log.getDefault().error(e, `Failed to trash file ${sessionFilePath}`);
+        return false;
+    }
+}
+
+export function isDirectory(sessionName) {
+    const sessionFilePath = GLib.build_filenamev([sessions_path, sessionName]);
+    if (GLib.file_test(sessionFilePath, GLib.FileTest.IS_DIR)) {
+        return true;
+    }
+
+    return false;
+}
+
+export function loadAutostartDesktopTemplate() {
+    return loadTemplate(desktop_template_path_restore_at_autostart);
+}
+
+export function loadDesktopTemplate(cancellable = null) {
+    return loadTemplate(desktop_template_path, cancellable);
+}
+
+export function loadTemplate(path, cancellable = null) {
+    const desktop_template_file = Gio.File.new_for_path(path);
+    let [success, contents] = desktop_template_file.load_contents(cancellable);
+    if (success) {
+        if (contents instanceof Uint8Array) {
+            return new TextDecoder().decode(contents);
+        } else {
+            // Unreachable code
+            return contents;
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Find the default app to open session file
+ *
+ * @param {string} filePath
+ */
+export function findDefaultApp(filePath) {
+    const session_file = Gio.File.new_for_path(filePath);
+    return new Promise((resolve, reject) => {
+        session_file.query_default_handler_async(
+            GLib.PRIORITY_DEFAULT,
+            null,
+            (file, asyncResult) => {
+                try {
+                    const app = session_file.query_default_handler_finish(asyncResult);
+                    if (app) {
+                        resolve([app, session_file]);
+                    } else {
+                        reject(new Error(`Cannot find the default application to ${filePath}`));
+                    }
+                } catch (error) {
+                    reject(error);
+                }
+            });
+    });
 }

--- a/utils/function.js
+++ b/utils/function.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-var callFunc = function (thisObj, func, param) {
+export const callFunc = function (thisObj, func, param) {
     try {
         if (!(param instanceof Array)) {
             if (param) {

--- a/utils/gnomeVersion.js
+++ b/utils/gnomeVersion.js
@@ -1,4 +1,9 @@
-const Config = imports.misc.config; 
+let Config;
+try {
+    Config = await import('resource:///org/gnome/shell/misc/config.js');
+} catch (e) {
+    Config = await import('resource:///org/gnome/Shell/Extensions/js/misc/config.js');
+}
 
 // '41.beta' => 41
 // '41.4' => 41.4
@@ -6,14 +11,14 @@ const Config = imports.misc.config;
 const GNOME_VERSION = parseFloat(Config.PACKAGE_VERSION);
 
 
-function isLessThan44() {
+export function isLessThan44() {
     return GNOME_VERSION < 44;
 }
 
-function isLessThan43() {
+export function isLessThan43() {
     return GNOME_VERSION < 43;
 }
 
-function isLessThan42() {
+export function isLessThan42() {
     return GNOME_VERSION < 42;
 }

--- a/utils/iconFinder.js
+++ b/utils/iconFinder.js
@@ -1,12 +1,21 @@
 'use strict';
 
-const { Gio, GLib } = imports.gi
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+// import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+let Extension;
+try {
+    let extensionObj = await import('resource:///org/gnome/shell/extensions/extension.js');
+    Extension = extensionObj.Extension;
+} catch (e) {
+    let extensionPrefsObj = await import('resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js');
+    Extension = extensionPrefsObj.ExtensionPreferences;
+}
 
-function find(iconName) {
-    let iconPath = `${Me.path}/icons/${iconName}`;
+export function find(iconName) {
+    const extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
+    let iconPath = `${extensionObject.path}/icons/${iconName}`;
     if (GLib.file_test(iconPath, GLib.FileTest.EXISTS)) {
         return Gio.icon_new_for_string(`${iconPath}`);
     }
@@ -15,8 +24,9 @@ function find(iconName) {
     
 }
 
-function findPath(iconName) {
-    let iconPath = `${Me.path}/icons/${iconName}`;
+export function findPath(iconName) {
+    const extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
+    let iconPath = `${extensionObject.path}/icons/${iconName}`;
     if (GLib.file_test(iconPath, GLib.FileTest.EXISTS)) {
         return iconPath;
     }

--- a/utils/log.js
+++ b/utils/log.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const PrefsUtils = Me.imports.utils.prefsUtils;
+import * as PrefsUtils from './prefsUtils.js';
 
 
-var Log = class {
+export const Log = class {
 
     constructor() {
         this._prefsUtils = new PrefsUtils.PrefsUtils();

--- a/utils/metaWindowUtils.js
+++ b/utils/metaWindowUtils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Meta } = imports.gi;
+import Meta from 'gi://Meta';
 
 
 /**
@@ -10,11 +10,11 @@ const { Meta } = imports.gi;
  * 
  * @returns stable window id
  */
-var getStableWindowId = function(metaWindow) {
+export const getStableWindowId = function(metaWindow) {
     return Meta.is_wayland_compositor() ? metaWindow.get_id() : metaWindow.get_description();
 }
 
-var isSurfaceActor = function(clutterActor) {
+export const isSurfaceActor = function(clutterActor) {
     const className = clutterActor.constructor.$gtype.name;
     // Excepted MetaSurfaceActorX11 and MetaSurfaceActorWayland on X11 and Wayland, respectively
     return className.startsWith('MetaSurfaceActor');

--- a/utils/prefsUtils.js
+++ b/utils/prefsUtils.js
@@ -42,8 +42,6 @@ export const PrefsUtils = class {
 
     destroy() {
         if (this.settings) {
-            // GObject.Object.run_dispose(): Releases all references to other objects.
-            this.settings.run_dispose();
             this.settings = null;
         }
         

--- a/utils/prefsUtils.js
+++ b/utils/prefsUtils.js
@@ -1,14 +1,27 @@
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
+// import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
-var SETTINGS_AUTORESTORE_SESSIONS = 'autorestore-sessions';
+let Extension;
+let _;
+try {
+    let extensionObj = await import('resource:///org/gnome/shell/extensions/extension.js');
+    Extension = extensionObj.Extension;
+    _ = extensionObj.gettext;
+} catch (e) {
+    let extensionPrefsObj = await import('resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js');
+    Extension = extensionPrefsObj.ExtensionPreferences;
+    _ = extensionPrefsObj.gettext;
+}
 
-var PrefsUtils = class {
+export const SETTINGS_AUTORESTORE_SESSIONS = 'autorestore-sessions';
+
+
+export const PrefsUtils = class {
 
     constructor() {
-        this.settings = ExtensionUtils.getSettings(
-            'org.gnome.shell.extensions.another-window-session-manager');
+        this.extensionObject = Extension.lookupByUUID('another-window-session-manager@gmail.com');
+        this.settings = this.extensionObject.getSettings('org.gnome.shell.extensions.another-window-session-manager');
     }
 
     getSettingString(settingName) {
@@ -17,6 +30,10 @@ var PrefsUtils = class {
 
     getSettings() {
         return this.settings;
+    }
+
+    getExtensionPath() {
+        return this.extensionObject.path;
     }
 
     isDebug() {

--- a/utils/signal.js
+++ b/utils/signal.js
@@ -1,6 +1,7 @@
-const { GObject } = imports.gi;
+import GObject from 'gi://GObject';
 
-var Signal = class {
+
+export const Signal = class {
 
     constructor() {
 

--- a/utils/subprocessUtils.js
+++ b/utils/subprocessUtils.js
@@ -1,19 +1,16 @@
 'use strict';
 
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const Log = Me.imports.utils.log;
+import * as Log from './log.js';
 
 const subprocessLauncher = new Gio.SubprocessLauncher({
     flags: (Gio.SubprocessFlags.STDOUT_PIPE |
             Gio.SubprocessFlags.STDERR_PIPE)});
 
 
-async function getProcessInfo(apps /*ShellApp*/, ignoreWindowsCb) {
+export async function getProcessInfo(apps /*ShellApp*/, ignoreWindowsCb) {
     try {
         const pidSet = new Set();
         for (const app of apps) {
@@ -98,7 +95,7 @@ function readOutput(stream, lineBuffer) {
  * subprocess might exit later with failure.
  * 
  */
-var trySpawnCmdstr = function(commandLineString, callBackOnSuccess, callBackOnFailure) {
+export const trySpawnCmdstr = function(commandLineString, callBackOnSuccess, callBackOnFailure) {
     let success_, argv;
 
     try {
@@ -150,7 +147,7 @@ var trySpawnCmdstr = function(commandLineString, callBackOnSuccess, callBackOnFa
  * exits, we cannot get the pid right after the subprocess launches. 
  * So there will be some kind of blocking here. 
  */
-var trySpawnCmdstrWithBlocking = function(commandLineString, callBackOnSuccess, callBackOnFailure) {
+export const trySpawnCmdstrWithBlocking = function(commandLineString, callBackOnSuccess, callBackOnFailure) {
     let success_, argv;
 
     try {
@@ -180,7 +177,7 @@ var trySpawnCmdstrWithBlocking = function(commandLineString, callBackOnSuccess, 
     });
 }
 
-var trySpawn = async function(commandLineArray, callBackOnSuccess, callBackOnFailure) {
+export const trySpawn = async function(commandLineArray, callBackOnSuccess, callBackOnFailure) {
     try {
         return await new Promise((resolve, reject) => {
             trySpawnAsync(commandLineArray,
@@ -210,7 +207,7 @@ var trySpawn = async function(commandLineArray, callBackOnSuccess, callBackOnFai
  * `callBackOnFailure` and `callBackOnFailure`
  * 
  */
-var trySpawnAsync = function(commandLineArray, callBackOnSuccess, callBackOnFailure) {
+export const trySpawnAsync = function(commandLineArray, callBackOnSuccess, callBackOnFailure) {
     try {
         let [, pid, stdin, stdout, stderr] = GLib.spawn_async_with_pipes(
             // Working directory, passing %null to use the parent's
@@ -296,7 +293,7 @@ var trySpawnAsync = function(commandLineArray, callBackOnSuccess, callBackOnFail
  * @param {Gio.Cancellable} [cancellable] - optional cancellable object
  * @returns {Promise<boolean>} - The process success
  */
- async function execCheck(argv, cancellable = null) {
+export async function execCheck(argv, cancellable = null) {
     let cancelId = 0;
     let proc = new Gio.Subprocess({
         argv: argv,

--- a/utils/tooltip.js
+++ b/utils/tooltip.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const Clutter = imports.gi.Clutter;
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const Pango = imports.gi.Pango;
-const St = imports.gi.St;
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Pango from 'gi://Pango';
+import St from 'gi://St';
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 /**
  * Note: Adapted from: https://github.com/GSConnect/gnome-shell-extension-gsconnect/blob/master/src/shell/tooltip.js
@@ -23,7 +23,7 @@ const Main = imports.ui.main;
 var TOOLTIP_BROWSE_ID = 0;
 var TOOLTIP_BROWSE_MODE = false;
 
-var Tooltip = class Tooltip {
+export const Tooltip = class Tooltip {
 
     constructor(params) {
         Object.assign(this, params);

--- a/windowTilingSupport.js
+++ b/windowTilingSupport.js
@@ -1,16 +1,15 @@
 'use strict';
 
-const { Shell, Meta, Gio, GObject } = imports.gi;
+import Shell from 'gi://Shell';
+import Meta from 'gi://Meta';
+import GObject from 'gi://GObject';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const Log = Me.imports.utils.log;
-const PrefsUtils = Me.imports.utils.prefsUtils;
+import * as Log from './utils/log.js';
+import * as PrefsUtils from './utils/prefsUtils.js';
 
 
 // Singleton class, all methods are `static`
-var WindowTilingSupport = class {
+export class WindowTilingSupport {
 
     static initialize() {
         this._log = new Log.Log();
@@ -204,7 +203,7 @@ var WindowTilingSupport = class {
 
 }
 
-var WindowTilingSupportSignals = GObject.registerClass({
+const WindowTilingSupportSignals = GObject.registerClass({
     Signals: {
         'window-tiled': {
             param_types: [Meta.Window.$gtype, Meta.Window.$gtype],


### PR DESCRIPTION
Related to https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager/issues/89

Please note that due to [gnome-shell 45 does not export `EndSessionDialog`](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/a42f7c23842ba186655f201db7edaf4b24590604/js/ui/endSessionDialog.js#L233), the flowing features do not work:
* [Restore previous apps and windows at startup](https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager/tree/main-gnome-45#restore-previous-apps-and-windows-at-startup) .
**Workaround**: I suggest to backup `currentSession` <details><summary></summary>Using `cp -r ~/.config/another-window-session-manager/currentSession ~/.config/another-window-session-manager/currentSession-bak` </details>before Log out/Reboot/Shutdown the computer, otherwise session files in `currentSession` will be removed automatically. Next time after logging in, rename the backup to `currentSession` <details><summary></summary>Using `mv ~/.config/another-window-session-manager/currentSession-bak/ ~/.config/another-window-session-manager/currentSession`</details>. And then run the following command to restore the previous session: 
`gdbus call --session --dest org.gnome.Shell.Extensions.awsm --object-path /org/gnome/Shell/Extensions/awsm --method org.gnome.Shell.Extensions.awsm.Autostart.RestorePreviousSession "{'removeAfterRestore': <false>}"`
* [Auto close session](https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager#auto-close-session)
This feature is not working, so the original end session dialog of Gnome will be popped up.

After [this MR](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2997) is merged, the above feature will be supported automatically based on the MR.
