### PR TITLE
Don't spam logs

### DIFF
--- a/utils/log.js
+++ b/utils/log.js
@@ -26,7 +26,7 @@ export const Log = class {
     }
 
     info(logContent) {
-        log(`[INFO   ][Another window session manager] ${logContent}`);
+        
     }
 
     warn(logContent) {


### PR DESCRIPTION
Actions like moving a window around spams the entire journal with unnecessary logs along with using up disk writes. Not sure why info exists when there is debug.