### PR TITLE
Added support for Gnome 47 and Gnome 48 With some styling improvement on prefs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,11 @@
     "name": "Another Window Session Manager",
     "shell-version": [
       "45",
-      "46"
+      "46",
+      "47",
+      "48"
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 49
+    "version": 50
   }

--- a/prefs.js
+++ b/prefs.js
@@ -8,7 +8,6 @@ import GdkWayland from 'gi://GdkWayland';
 import Gdk from 'gi://Gdk';
 
 import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
-
 import * as FileUtils from './utils/fileUtils.js';
 import * as Log from './utils/log.js';
 import {prefsUtilsInit, prefsUtilsDestroy, PrefsUtils} from './utils/prefsUtils.js';
@@ -272,7 +271,6 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
 
         this.close_by_rules_switch = this._builder.get_object('close_by_rules_switch');
         this.auto_close_session_switch = this._builder.get_object('auto_close_session_switch');
-
     }
 
     _installAutostartDesktopFile(desktopFileTemplate, targetDesktopFilePath) {

--- a/prefsCloseWindow.js
+++ b/prefsCloseWindow.js
@@ -51,7 +51,7 @@ export const UICloseWindows = GObject.registerClass(
             const settingKey = 'close-windows-whitelist';
             const close_windows_whitelist_listbox = this._builder.get_object('close_windows_whitelist_listbox');
             close_windows_whitelist_listbox.set_header_func((currentRow, beforeRow, data) => {
-                this._setHeader(currentRow, beforeRow, data, 'Whitelist', {margin_start: 0});
+                this._setHeader(currentRow, beforeRow, data, 'Whitelist');
             });
 
             const whitelistColumnView = new PrefsColumnView.WhitelistColumnView();
@@ -186,7 +186,7 @@ export const UICloseWindows = GObject.registerClass(
                     margin_start: 12,
                     use_markup: true,
                     label: `<b>${headerName}</b>`,
-                    tooltip_text: 'Apps in the whitelist will be closed even they has multiple windows'
+                    tooltip_text: 'Apps in the whitelist will be closed even if they have multiple windows'
                 });
                 if (labelProperties)
                     Object.assign(label, labelProperties);

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -215,8 +215,10 @@
                         <property name="margin-bottom">12</property>
                         <property name="row-spacing">6</property>
                         <property name="column-spacing">32</property>
+                        <property name="margin_start">6</property>
                         <child>
                           <object class="GtkLabel" id="save_session_notification_label">
+                            <property name="margin_top">12</property>
                             <property name="hexpand">1</property>
                             <property name="label" translatable="yes">Session is saved notification</property>
                             <property name="use-markup">1</property>
@@ -229,6 +231,7 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="save_session_notification_switch">
+                            <property name="margin_end">6</property>
                             <property name="focusable">1</property>
                             <property name="active">1</property>
                             <property name="halign">end</property>
@@ -297,7 +300,10 @@
                                 <property name="margin-top">12</property>
                                 <property name="row-spacing">6</property>
                                 <property name="column-spacing">32</property>
-                                <property name="margin-top">12</property><child>
+                                <property name="margin-top">12</property>
+                                <property name="margin_start">6</property>
+                                <property name="margin_end">6</property>
+                                <child>
                                   <object class="GtkLabel">
                                     <property name="hexpand">1</property>
                                     <property name="label" translatable="yes">Restore previous apps and windows at startup</property>
@@ -349,6 +355,9 @@
                                 <property name="margin-bottom">12</property>
                                 <property name="row-spacing">6</property>
                                 <property name="column-spacing">32</property>
+                                <property name="margin_start">6</property>
+                                <property name="margin_top">12</property>
+                                <property name="margin_end">12</property>
                                 <child>
                                   <object class="GtkLabel" id="restore_previous_delay_multi_label">
                                     <property name="hexpand">1</property>
@@ -412,6 +421,8 @@
                             <property name="margin-bottom">12</property>
                             <property name="row-spacing">6</property>
                             <property name="column-spacing">32</property>
+                            <property name="margin_start">6</property>
+                            <property name="margin_end">12</property>
                             <child>
                               <object class="GtkLabel" id="restore_at_startup_multi_label">
                                 <property name="hexpand">1</property>
@@ -539,6 +550,8 @@
                                 <property name="margin-top">12</property>
                                 <property name="row-spacing">6</property>
                                 <property name="column-spacing">32</property>
+                                <property name="margin_start">6</property>
+                                <property name="margin_end">12</property>
                                 <child>
                                   <object class="GtkLabel" id="restore_session_interval_label">
                                     <property name="hexpand">1</property>
@@ -594,6 +607,9 @@
                                 <property name="margin-bottom">12</property>
                                 <property name="row-spacing">6</property>
                                 <property name="column-spacing">32</property>
+                                <property name="margin_start">6</property>
+                                <property name="margin_top">6</property>
+                                <property name="margin_end">6</property>
                                 <child>
                                   <object class="GtkLabel" id="autostart_delay_multi_label">
                                     <property name="hexpand">1</property>
@@ -655,6 +671,10 @@
                             <property name="focusable">1</property>
                             <property name="child">
                               <object class="GtkBox">
+                                <property name="margin_start">6</property>
+                                <property name="margin_top">6</property>
+                                <property name="margin_end">6</property>
+                                <property name="margin_bottom">6</property>
                                 <child>
                                   <object class="GtkLabel" id="restore_window_tiling_label">
                                     <property name="label" translatable="yes">Restore window tiling</property>
@@ -678,6 +698,10 @@
                             <property name="focusable">1</property>
                             <property name="child">
                               <object class="GtkBox">
+                                <property name="margin_start">6</property>
+                                <property name="margin_end">6</property>
+                                <property name="margin_top">6</property>
+                                <property name="margin_bottom">6</property>
                                 <child>
                                   <object class="GtkLabel">
                                     <property name="label" translatable="yes">Raise windows together</property>
@@ -711,6 +735,9 @@
                             <property name="child">
                               <object class="GtkGrid">
                                 <property name="margin-bottom">12</property>
+                                <property name="margin_start">6</property>
+                                <property name="margin_end">6</property>
+                                <property name="margin_top">6</property>
                                 <property name="row-spacing">6</property>
                                 <property name="column-spacing">32</property>
                                 <child>
@@ -792,6 +819,8 @@
                     <property name="focusable">1</property>
                     <property name="margin-top">12</property>
                     <property name="margin-bottom">12</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
                     <property name="child">
                       <object class="GtkBox">
                         <child>
@@ -836,6 +865,9 @@
                     <property name="child">
                       <object class="GtkGrid" id="debugging_mode_multi_grid">
                         <property name="margin-top">12</property>
+                        <property name="margin-bottom">6</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_end">6</property>
                         <property name="row-spacing">6</property>
                         <property name="column-spacing">32</property>
                         <child>
@@ -874,6 +906,9 @@
                       <property name="child">
                         <object class="GtkGrid" id="verbose_logging_grid">
                         <property name="margin-bottom">12</property>
+                        <property name="margin-top">12</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_end">6</property>
                         <property name="row-spacing">6</property>
                         <property name="column-spacing">32</property>
                         <child>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -47,6 +47,8 @@
                           <object class="GtkGrid" id="auto_close_session_multi_grid1">
                             <property name="margin-top">12</property>
                             <property name="margin-bottom">12</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
                             <property name="row-spacing">6</property>
                             <property name="column-spacing">32</property>
                             <child>
@@ -103,6 +105,8 @@
                           <object class="GtkGrid" id="close_by_rules_multi_grid1">
                             <property name="margin-top">12</property>
                             <property name="margin-bottom">12</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
                             <property name="row-spacing">6</property>
                             <property name="column-spacing">32</property>
                             <child>
@@ -191,6 +195,9 @@
   </object>
   <object class="AdwPreferencesPage" id="save_windows_page">
     <property name="use_underline">true</property>
+    <property name="margin_bottom">12</property>
+    <property name="margin_start">12</property>
+    <property name="margin_end">12</property>
     <property name="title" translatable="yes">Save windows</property>
     <child>
       <object class="GtkBox">
@@ -266,6 +273,9 @@
     <property name="title" translatable="yes">Restore sessions</property>
     <child>
       <object class="GtkScrolledWindow">
+        <property name="margin_bottom">12</property>
+        <property name="margin_start">12</property>
+        <property name="margin_end">12</property>
         <property name="hscrollbar_policy">never</property>
         <child>
           <object class="GtkViewport">
@@ -763,6 +773,9 @@
   </object>
   <object class="AdwPreferencesPage" id="general_page">
     <property name="use_underline">true</property>
+    <property name="margin_bottom">12</property>
+    <property name="margin_start">12</property>
+    <property name="margin_end">12</property>
     <property name="title" translatable="yes">General</property>
     <child>
       <object class="GtkBox">

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -24,7 +24,7 @@
   </object>
 
   <object class="AdwPreferencesPage" id="close_windows_page">
-    <!-- <property name="icon-name">text-x-generic-symbolic</property> -->
+    <property name="icon-name">window-close-symbolic</property>
     <property name="use_underline">true</property>
     <property name="title" translatable="yes">Close windows</property>
     <child>
@@ -194,6 +194,7 @@
     </child>
   </object>
   <object class="AdwPreferencesPage" id="save_windows_page">
+    <property name="icon-name">document-save-symbolic</property>
     <property name="use_underline">true</property>
     <property name="margin_bottom">12</property>
     <property name="margin_start">12</property>
@@ -272,6 +273,7 @@
     </child>
   </object>
   <object class="AdwPreferencesPage" id="restore_sessions_page">
+    <property name="icon-name">view-refresh-symbolic</property>
     <property name="use_underline">true</property>
     <property name="title" translatable="yes">Restore sessions</property>
     <child>
@@ -799,6 +801,7 @@
     </child>
   </object>
   <object class="AdwPreferencesPage" id="general_page">
+    <property name="icon-name">preferences-system-symbolic</property>
     <property name="use_underline">true</property>
     <property name="margin_bottom">12</property>
     <property name="margin_start">12</property>


### PR DESCRIPTION
This pull request includes styling improvements, specifically by adjusting the margins in the preferences window. It also adds support for GNOME versions 47 and 48 in the manifest, as no dependency warnings were encountered during testing. Additionally, Gnome default icons have been added to the preferences tabs; this is necessary to avoid displaying broken icons in the window, which was the case beforehand.