### PR TITLE
Migrated unsupported GTK UI-widgets to AdwPreferencesGroups

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,5 +11,5 @@
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 52
+    "version": 53
   }

--- a/prefs.js
+++ b/prefs.js
@@ -18,7 +18,8 @@ import * as PrefsCloseWindow from './prefsCloseWindow.js';
 
 export default class AnotherWindowSessionManagerPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
-        window.set_default_size(1202, 800);
+        window.set_default_size(1200, 800);
+        window.set_size_request(1200, 800);
 
         const settings = this.getSettings('org.gnome.shell.extensions.another-window-session-manager');
         

--- a/prefs.js
+++ b/prefs.js
@@ -230,11 +230,11 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
         this.timer_on_the_autostart_dialog_spinbutton = this._builder.get_object('timer_on_the_autostart_dialog_spinbutton');
         this.autostart_delay_spinbutton = this._builder.get_object('autostart_delay_spinbutton');
         this.restore_window_tiling_switch = this._builder.get_object('restore_window_tiling_switch');
+        this.raise_windows_together_switch = this._builder.get_object('raise_windows_together_switch');
         this.restore_window_tiling_switch.connect('notify::active', (widget) => {
             const active = widget.active;
             this.raise_windows_together_switch.set_sensitive(active);
         });
-        this.raise_windows_together_switch = this._builder.get_object('raise_windows_together_switch');
         this.stash_and_restore_states_switch = this._builder.get_object('stash_and_restore_states_switch');
 
         this.restore_previous_delay_spinbutton = this._builder.get_object('restore_previous_delay_spinbutton');

--- a/prefs.js
+++ b/prefs.js
@@ -18,7 +18,7 @@ import * as PrefsCloseWindow from './prefsCloseWindow.js';
 
 export default class AnotherWindowSessionManagerPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
-        window.set_default_size(1000, 800);
+        window.set_default_size(1202, 800);
 
         const settings = this.getSettings('org.gnome.shell.extensions.another-window-session-manager');
         

--- a/prefs.js
+++ b/prefs.js
@@ -27,7 +27,8 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
         this._log = new Log.Log();
 
         this.render_ui();
-        new PrefsCloseWindow.UICloseWindows(this._builder).init();
+        this._uiCloseWindows = new PrefsCloseWindow.UICloseWindows(this._builder);
+        this._uiCloseWindows.init();
         this._bindSettings();
         
         // Set sensitive AFTER this._bindSettings() to make it work
@@ -304,6 +305,12 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
     }
 
     _destroy() {
+        // Destroy UICloseWindows first to clear ListBox header functions
+        if (this._uiCloseWindows) {
+            this._uiCloseWindows.destroy();
+            this._uiCloseWindows = null;
+        }
+        
         prefsUtilsDestroy();
         
     }

--- a/prefsCloseWindow.js
+++ b/prefsCloseWindow.js
@@ -448,7 +448,7 @@ const RuleRow = GObject.registerClass({
                 value: savedKeyDelay ? savedKeyDelay : 0
             }),
             snap_to_ticks: true,
-            margin_end: 6,
+            margin_end: 4,
         });
         spinButton.connect('value-changed', (source) => {
             const keyDelayValue = source.get_value();

--- a/prefsCloseWindow.js
+++ b/prefsCloseWindow.js
@@ -62,6 +62,12 @@ export const UICloseWindows = GObject.registerClass(
             const whitelistColumnView = new PrefsColumnView.WhitelistColumnView();
             const addWhitelist = new AwsmNewRuleRow();
             close_windows_whitelist_listbox.append(whitelistColumnView);
+            // Get the auto-created ListBoxRow and make it non-activatable
+            const whitelistRow = whitelistColumnView.get_parent();
+            if (whitelistRow instanceof Gtk.ListBoxRow) {
+                whitelistRow.set_activatable(false);
+                whitelistRow.set_selectable(false);
+            }
             close_windows_whitelist_listbox.append(addWhitelist);
 
             addWhitelist.connect('clicked', (source) => {

--- a/prefsCloseWindow.js
+++ b/prefsCloseWindow.js
@@ -2,6 +2,7 @@
 
 import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
+import GioUnix from 'gi://GioUnix';
 import GLib from 'gi://GLib';
 import Gtk from 'gi://Gtk';
 import Pango from 'gi://Pango';
@@ -769,7 +770,7 @@ const RuleRowByApp = GObject.registerClass({
     _init(ruleDetail) {
         super._init(ruleDetail);
 
-        const appInfo = Gio.DesktopAppInfo.new_from_filename(ruleDetail.appDesktopFilePath)
+        const appInfo = GioUnix.DesktopAppInfo.new_from_filename(ruleDetail.appDesktopFilePath)
         this._appInfo = appInfo;
 
         let displayName

--- a/prefsCloseWindow.js
+++ b/prefsCloseWindow.js
@@ -38,6 +38,9 @@ export const UICloseWindows = GObject.registerClass(
 
             // TODO
             this._scrollToWidget = null;
+            
+            // Store ListBox references for cleanup
+            this._listBoxes = [];
         }
 
         init() {
@@ -50,6 +53,7 @@ export const UICloseWindows = GObject.registerClass(
         _initWhitelist() {
             const settingKey = 'close-windows-whitelist';
             const close_windows_whitelist_listbox = this._builder.get_object('close_windows_whitelist_listbox');
+            this._listBoxes.push(close_windows_whitelist_listbox);
             close_windows_whitelist_listbox.set_header_func((currentRow, beforeRow, data) => {
                 this._setHeader(currentRow, beforeRow, data, 'Whitelist');
             });
@@ -103,6 +107,7 @@ export const UICloseWindows = GObject.registerClass(
 
         _initAppRules() {
             const close_by_rules_list_box = this._builder.get_object('close_by_rules_applications_list_box');
+            this._listBoxes.push(close_by_rules_list_box);
             close_by_rules_list_box.set_header_func((currentRow, beforeRow, data) => {
                 this._setHeader(currentRow, beforeRow, data, 'Applications');
             });
@@ -136,6 +141,7 @@ export const UICloseWindows = GObject.registerClass(
 
         _initKeywordRules() {
             const close_by_rules_by_keyword_list_box = this._builder.get_object('close_by_rules_keywords_list_box');
+            this._listBoxes.push(close_by_rules_by_keyword_list_box);
             close_by_rules_by_keyword_list_box.set_header_func((currentRow, beforeRow, data) => {
                 this._setHeader(currentRow, beforeRow, data, 'Keywords');
             });
@@ -276,6 +282,30 @@ export const UICloseWindows = GObject.registerClass(
             removed.forEach(r => {
                 listBox.remove(r);
             });
+        }
+
+        destroy() {
+            // Clear header functions to prevent callbacks during shutdown
+            if (this._listBoxes) {
+                this._listBoxes.forEach(listBox => {
+                    if (listBox) {
+                        listBox.set_header_func(null);
+                    }
+                });
+                this._listBoxes = null;
+            }
+            
+            // Disconnect settings signals
+            if (this._settings) {
+                if (this._changedId) {
+                    this._settings.disconnect(this._changedId);
+                    this._changedId = null;
+                }
+                if (this._rulesChangedId) {
+                    this._settings.disconnect(this._rulesChangedId);
+                    this._rulesChangedId = null;
+                }
+            }
         }
 
     });

--- a/prefsColumnView.js
+++ b/prefsColumnView.js
@@ -35,7 +35,7 @@ export const ColumnView = GObject.registerClass({
 
     _initUI() {
         this.model = new Gio.ListStore({ item_type: GObject.TYPE_OBJECT });
-        this.selectionModel = new Gtk.SingleSelection({ model: this.model });
+        this.selectionModel = new Gtk.NoSelection({ model: this.model });
 
         this.view = new Gtk.ColumnView({
             css_classes: ['view'],

--- a/schemas/org.gnome.shell.extensions.another-window-session-manager.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.another-window-session-manager.gschema.xml
@@ -131,7 +131,7 @@
       Stash states while Gnome Shell restarts via `Alt+F2 -> r` or `killall -3 gnome-shell`, 
       and restore the windows states after the restart finishes.
       
-      Only enabled on X11, since Wayand doesn't support restart on fly.
+      Only enabled on X11, since Wayland doesn't support restart on fly.
       </description>
     </key>
     <key name="show-indicator" type="b">

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -1,23 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
+  <requires lib="Adw" version="1.0"/>
   <object class="GtkAdjustment" id="timer_on_the_autostart_dialog_adjustment">
+    <property name="lower">0</property>
     <property name="upper">3600</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="restore_previous_delay_adjustment">
+    <property name="lower">0</property>
     <property name="upper">3600</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="restore_session_interval_spinbutton_adjustment">
+    <property name="lower">0</property>
     <property name="upper">300000</property>
     <property name="step-increment">1</property>
     <property name="page-increment">100</property>
   </object>
 
   <object class="GtkAdjustment" id="autostart_delay_adjustment">
+    <property name="lower">0</property>
     <property name="upper">3600</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
@@ -28,166 +33,166 @@
     <property name="use_underline">true</property>
     <property name="title" translatable="yes">Close windows</property>
     <child>
-      <object class="GtkScrolledWindow">
-        <property name="hscrollbar_policy">always</property>
-        <property name="vscrollbar_policy">always</property>
+      <object class="AdwPreferencesGroup" id="close_windows_group">
+        <property name="title" translatable="yes">Close windows</property>
         <child>
-          <object class="GtkViewport">
-            <property name="focusable">False</property>
-            <property name="vexpand">True</property>
-            <child>
-              <object class="GtkBox" id="close_windows_box">
-                <property name="orientation">vertical</property>
+          <object class="GtkFrame" id="close_windows_frame">
+            <property name="child">
+              <object class="GtkListBox">
                 <child>
-                  <object class="GtkListBox">
-                    <child>
-                      <object class="GtkListBoxRow" id="auto_close_session_multi_row">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid" id="auto_close_session_multi_grid1">
-                            <property name="margin-top">12</property>
-                            <property name="margin-bottom">12</property>
-                            <property name="margin_start">12</property>
-                            <property name="margin_end">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="auto_close_session_multi_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Auto close session</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="auto_close_session_switch">
-                                <property name="focusable">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="auto_close_session_multi_label_description">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Enable to close running apps and windows while Logout, Reboot and Shutdown via endSessionDialog.</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
+                  <object class="GtkListBoxRow" id="auto_close_session_multi_row">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkGrid" id="auto_close_session_multi_grid1">
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="auto_close_session_multi_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Auto close session</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
-                        </property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkListBoxRow" id="close_by_rules_multi_row">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid" id="close_by_rules_multi_grid1">
-                            <property name="margin-top">12</property>
-                            <property name="margin-bottom">12</property>
-                            <property name="margin_start">12</property>
-                            <property name="margin_end">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <child>
-                              <object class="GtkLabel" id="close_by_rules_multi_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Close by rules</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="close_by_rules_switch">
-                                <property name="focusable">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="close_by_rules_multi_label_description">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">To make this feature work, see: &lt;a href='https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager#how-to-make-close-by-rules-work'&gt;How to make `Close by rules` work&lt;/a&gt;</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="auto_close_session_switch">
+                            <property name="focusable">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
                           </object>
-                        </property>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="auto_close_session_multi_label_description">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Enable to close running apps and windows while Logout, Reboot and Shutdown via endSessionDialog.</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
                       </object>
-                    </child>
+                    </property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkBox">
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkListBox" id="close_by_rules_applications_list_box">
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="show-separators">True</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkListBox" id="close_by_rules_keywords_list_box">
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="show-separators">True</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkListBox" id="close_windows_whitelist_listbox">
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="show-separators">True</property>
+                  <object class="GtkListBoxRow" id="close_by_rules_multi_row">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkGrid" id="close_by_rules_multi_grid1">
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="margin_start">12</property>
+                        <property name="margin_end">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
                         <child>
+                          <object class="GtkLabel" id="close_by_rules_multi_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Close by rules</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="close_by_rules_switch">
+                            <property name="focusable">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="close_by_rules_multi_label_description">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">To make this feature work, see: &lt;a href='https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager#how-to-make-close-by-rules-work'&gt;How to make `Close by rules` work&lt;/a&gt;</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
-                    </child>
+                    </property>
                   </object>
                 </child>
               </object>
-            </child>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="close_by_rules_applications_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox" id="close_by_rules_applications_list_box">
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="show-separators">True</property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="close_by_rules_keywords_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox" id="close_by_rules_keywords_list_box">
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="show-separators">True</property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="close_windows_whitelist_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox" id="close_windows_whitelist_listbox">
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="show-separators">True</property>
+              </object>
+            </property>
           </object>
         </child>
       </object>
@@ -196,16 +201,12 @@
   <object class="AdwPreferencesPage" id="save_windows_page">
     <property name="icon-name">document-save-symbolic</property>
     <property name="use_underline">true</property>
-    <property name="margin_bottom">12</property>
-    <property name="margin_start">12</property>
-    <property name="margin_end">12</property>
     <property name="title" translatable="yes">Save windows</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
+      <object class="AdwPreferencesGroup" id="save_windows_group">
+        <property name="title" translatable="yes">Save windows</property>
         <child>
           <object class="GtkFrame" id="save_session_notification_frame">
-            <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox">
                 <child>
@@ -277,134 +278,60 @@
     <property name="use_underline">true</property>
     <property name="title" translatable="yes">Restore sessions</property>
     <child>
-      <object class="GtkScrolledWindow">
-        <property name="margin_bottom">12</property>
-        <property name="margin_start">12</property>
-        <property name="margin_end">12</property>
-        <property name="hscrollbar_policy">never</property>
+      <object class="AdwPreferencesGroup" id="restore_sessions_group">
+        <property name="title" translatable="yes">Restore sessions</property>
         <child>
-          <object class="GtkViewport">
-            <property name="focusable">False</property>
-            <property name="vexpand">True</property>
-            <child>
-              <object class="GtkBox">
-                <property name="margin-top">30</property>
-                <property name="orientation">vertical</property>
+          <object class="GtkFrame" id="restore_previous_frame">
+            <property name="child">
+              <object class="GtkListBox">
                 <child>
-                  <object class="GtkFrame" id="restore_previous_frame">
+                  <object class="GtkListBoxRow" id="restore_previous_multi_row">
+                    <property name="focusable">1</property>
                     <property name="child">
-                      <object class="GtkListBox">
+                      <object class="GtkGrid">
+                        <property name="margin-top">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_end">6</property>
                         <child>
-                          <object class="GtkListBoxRow" id="restore_previous_multi_row">
-                            <property name="focusable">1</property>
-                            <property name="child">
-                              <object class="GtkGrid">
-                                <property name="margin-top">12</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">32</property>
-                                <property name="margin-top">12</property>
-                                <property name="margin_start">6</property>
-                                <property name="margin_end">6</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Restore previous apps and windows at startup</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSwitch" id="restore_previous_switch">
-                                    <property name="focusable">1</property>
-                                    <property name="halign">end</property>
-                                    <property name="valign">center</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                      <property name="row-span">2</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Install ~/.config/autostart/_awsm-restore-previous-session.desktop if enabled</property>
-                                    <property name="wrap">True</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
+                          <object class="GtkLabel">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Restore previous apps and windows at startup</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
                         </child>
                         <child>
-                          <object class="GtkListBoxRow">
+                          <object class="GtkSwitch" id="restore_previous_switch">
                             <property name="focusable">1</property>
-                            <property name="child">
-                              <object class="GtkGrid" id="restore_previous_delay_multi_grid">
-                                <property name="margin-bottom">12</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">32</property>
-                                <property name="margin_start">6</property>
-                                <property name="margin_top">12</property>
-                                <property name="margin_end">12</property>
-                                <child>
-                                  <object class="GtkLabel" id="restore_previous_delay_multi_label">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Restore delay([0, 3600]s)</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="restore_previous_delay_spinbutton">
-                                    <property name="focusable">1</property>
-                                    <property name="text" translatable="yes">10</property>
-                                    <property name="adjustment">restore_previous_delay_adjustment</property>
-                                    <property name="numeric">1</property>
-                                    <property name="value">10</property>
-                                    <property name="valign">center</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                      <property name="row-span">2</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">5 by default.</property>
-                                    <property name="wrap">True</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Install ~/.config/autostart/_awsm-restore-previous-session.desktop if enabled</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
                           </object>
                         </child>
                       </object>
@@ -412,381 +339,57 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkFrame" id="restore_window_frame">
-                    <property name="margin-top">30</property>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
                     <property name="child">
-                      <object class="GtkListBoxRow" id="restore_at_startup_multi_row">
-                        <property name="focusable">1</property>
-                        <property name="child">
-                          <object class="GtkGrid" id="restore_at_startup_multi_grid">
-                            <property name="margin-top">12</property>
-                            <property name="margin-bottom">12</property>
-                            <property name="row-spacing">6</property>
-                            <property name="column-spacing">32</property>
-                            <property name="margin_start">6</property>
-                            <property name="margin_end">12</property>
-                            <child>
-                              <object class="GtkLabel" id="restore_at_startup_multi_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Restore selected session at startup</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">0</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="restore_at_startup_switch">
-                                <property name="focusable">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">0</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Install ~/.config/autostart/_gnome-shell-extension-another-window-session-manager.desktop if enabled</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">1</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="restore_at_startup_without_asking_multi_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Restore at startup without asking</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSwitch" id="restore_at_startup_without_asking_switch">
-                                <property name="focusable">1</property>
-                                <property name="halign">end</property>
-                                <property name="valign">center</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="timer_on_the_autostart_dialog_multi_label">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">Timer on the autostart dialog([0, 3600]s)</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">3</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkSpinButton" id="timer_on_the_autostart_dialog_spinbutton">
-                                <property name="focusable">1</property>
-                                <property name="text" translatable="yes">10</property>
-                                <property name="adjustment">timer_on_the_autostart_dialog_adjustment</property>
-                                <property name="numeric">1</property>
-                                <property name="value">10</property>
-                                <layout>
-                                  <property name="column">1</property>
-                                  <property name="row">3</property>
-                                  <property name="row-span">2</property>
-                                </layout>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="hexpand">1</property>
-                                <property name="label" translatable="yes">10 by default.</property>
-                                <property name="wrap">True</property>
-                                <property name="use-markup">1</property>
-                                <property name="xalign">0</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                                <layout>
-                                  <property name="column">0</property>
-                                  <property name="row">4</property>
-                                </layout>
-                              </object>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
-                    </property>
-                    <child type="label_item">
-                      <placeholder/>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFrame" id="restore_session_interval_frame">
-                    <property name="margin-top">30</property>
-                    <property name="child">
-                      <object class="GtkListBox">
+                      <object class="GtkGrid" id="restore_previous_delay_multi_grid">
+                        <property name="margin-bottom">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_top">12</property>
+                        <property name="margin_end">12</property>
                         <child>
-                          <object class="GtkListBoxRow">
-                            <property name="focusable">1</property>
-                            <property name="child">
-                              <object class="GtkGrid">
-                                <property name="margin-top">12</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">32</property>
-                                <property name="margin_start">6</property>
-                                <property name="margin_end">12</property>
-                                <child>
-                                  <object class="GtkLabel" id="restore_session_interval_label">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Restore applications interval([0, 300000]ms)</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="restore_session_interval_spinbutton">
-                                    <property name="focusable">1</property>
-                                    <property name="text" translatable="yes">10</property>
-                                    <property name="adjustment">restore_session_interval_spinbutton_adjustment</property>
-                                    <property name="numeric">1</property>
-                                    <property name="value">0</property>
-                                    <property name="valign">center</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                      <property name="row-span">2</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="restore_session_interval_label_description">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">0 by default. There's no need to set this option normally, unless the process of restoring session is too fast to freeze the system, for example.</property>
-                                    <property name="wrap">True</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
+                          <object class="GtkLabel" id="restore_previous_delay_multi_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Restore delay([0, 3600]s)</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
                           </object>
                         </child>
                         <child>
-                          <object class="GtkListBoxRow">
+                          <object class="GtkSpinButton" id="restore_previous_delay_spinbutton">
                             <property name="focusable">1</property>
-                            <property name="child">
-                              <object class="GtkGrid">
-                                <property name="margin-bottom">12</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">32</property>
-                                <property name="margin_start">6</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_end">6</property>
-                                <child>
-                                  <object class="GtkLabel" id="autostart_delay_multi_label">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Autostart delay([0, 3600]s)</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="autostart_delay_spinbutton">
-                                    <property name="focusable">1</property>
-                                    <property name="text" translatable="yes">20</property>
-                                    <property name="adjustment">autostart_delay_adjustment</property>
-                                    <property name="numeric">1</property>
-                                    <property name="value">20</property>
-                                    <property name="valign">center</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                      <property name="row-span">2</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="autostart_delay_multi_label_description">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">5 by default. Delay before restoring session at startup or the previous session. If the delay is too short, the computer might freeze.</property>
-                                    <property name="wrap">True</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                          </object>
-                        </child>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFrame" id="restore_window_tiling_frame">
-                    <property name="margin-top">30</property>
-                    <property name="child">
-                      <object class="GtkListBox">
-                        <child>
-                          <object class="GtkListBoxRow">
-                            <property name="focusable">1</property>
-                            <property name="child">
-                              <object class="GtkBox">
-                                <property name="margin_start">6</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_end">6</property>
-                                <property name="margin_bottom">6</property>
-                                <child>
-                                  <object class="GtkLabel" id="restore_window_tiling_label">
-                                    <property name="label" translatable="yes">Restore window tiling</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSwitch" id="restore_window_tiling_switch">
-                                    <property name="focusable">1</property>
-                                    <property name="active">1</property>
-                                    <property name="halign">end</property>
-                                    <property name="valign">center</property>
-                                    <property name="hexpand">1</property>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
+                            <property name="text" translatable="yes">10</property>
+                            <property name="adjustment">restore_previous_delay_adjustment</property>
+                            <property name="numeric">1</property>
+                            <property name="value">10</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
                           </object>
                         </child>
                         <child>
-                          <object class="GtkListBoxRow">
-                            <property name="focusable">1</property>
-                            <property name="child">
-                              <object class="GtkBox">
-                                <property name="margin_start">6</property>
-                                <property name="margin_end">6</property>
-                                <property name="margin_top">6</property>
-                                <property name="margin_bottom">6</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="label" translatable="yes">Raise windows together</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSwitch" id="raise_windows_together_switch">
-                                    <property name="focusable">1</property>
-                                    <property name="active">1</property>
-                                    <property name="halign">end</property>
-                                    <property name="valign">center</property>
-                                    <property name="hexpand">1</property>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
-                          </object>
-                        </child>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFrame" id="stash_and_restore_states_frame">
-                    <property name="margin-top">30</property>
-                    <property name="child">
-                      <object class="GtkListBox">
-                        <child>
-                          <object class="GtkListBoxRow">
-                            <property name="focusable">1</property>
-                            <property name="child">
-                              <object class="GtkGrid">
-                                <property name="margin-bottom">12</property>
-                                <property name="margin_start">6</property>
-                                <property name="margin_end">6</property>
-                                <property name="margin_top">6</property>
-                                <property name="row-spacing">6</property>
-                                <property name="column-spacing">32</property>
-                                <child>
-                                  <object class="GtkLabel" id="stash_and_restore_states_label">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Restore windows states after Gnome Shell restarts</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSwitch" id="stash_and_restore_states_switch">
-                                    <property name="focusable">1</property>
-                                    <property name="active">1</property>
-                                    <property name="halign">end</property>
-                                    <property name="valign">center</property>
-                                    <property name="hexpand">1</property>
-                                    <layout>
-                                      <property name="column">1</property>
-                                      <property name="row">0</property>
-                                      <property name="row-span">2</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="hexpand">1</property>
-                                    <property name="label" translatable="yes">Only enabled on X11, since Wayand doesn't support restart Gnome Shell via `Alt+F2 then type r` or `killall -3 gnome-shell`.</property>
-                                    <property name="wrap">True</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="xalign">0</property>
-                                    <property name="valign">center</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                    <layout>
-                                      <property name="column">0</property>
-                                      <property name="row">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                              </object>
-                            </property>
+                          <object class="GtkLabel">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">5 by default.</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
                           </object>
                         </child>
                       </object>
@@ -794,7 +397,390 @@
                   </object>
                 </child>
               </object>
-            </child>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="restore_window_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox">
+                <child>
+                  <object class="GtkListBoxRow" id="restore_at_startup_multi_row">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkGrid" id="restore_at_startup_multi_grid">
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_end">12</property>
+                        <child>
+                          <object class="GtkLabel" id="restore_at_startup_multi_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Restore selected session at startup</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="restore_at_startup_switch">
+                            <property name="focusable">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Install ~/.config/autostart/_gnome-shell-extension-another-window-session-manager.desktop if enabled</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="restore_at_startup_without_asking_multi_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Restore at startup without asking</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="restore_at_startup_without_asking_switch">
+                            <property name="focusable">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="timer_on_the_autostart_dialog_multi_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Timer on the autostart dialog([0, 3600]s)</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">3</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="timer_on_the_autostart_dialog_spinbutton">
+                            <property name="focusable">1</property>
+                            <property name="text" translatable="yes">10</property>
+                            <property name="adjustment">timer_on_the_autostart_dialog_adjustment</property>
+                            <property name="numeric">1</property>
+                            <property name="value">10</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">3</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">10 by default.</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">4</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="restore_session_interval_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox">
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkGrid">
+                        <property name="margin-top">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_end">12</property>
+                        <child>
+                          <object class="GtkLabel" id="restore_session_interval_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Restore applications interval([0, 300000]ms)</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="restore_session_interval_spinbutton">
+                            <property name="focusable">1</property>
+                            <property name="text" translatable="yes">10</property>
+                            <property name="adjustment">restore_session_interval_spinbutton_adjustment</property>
+                            <property name="numeric">1</property>
+                            <property name="value">0</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="restore_session_interval_label_description">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">0 by default. There's no need to set this option normally, unless the process of restoring session is too fast to freeze the system, for example.</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkGrid">
+                        <property name="margin-bottom">12</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_end">6</property>
+                        <child>
+                          <object class="GtkLabel" id="autostart_delay_multi_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Autostart delay([0, 3600]s)</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="autostart_delay_spinbutton">
+                            <property name="focusable">1</property>
+                            <property name="text" translatable="yes">20</property>
+                            <property name="adjustment">autostart_delay_adjustment</property>
+                            <property name="numeric">1</property>
+                            <property name="value">20</property>
+                            <property name="valign">center</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="autostart_delay_multi_label_description">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">5 by default. Delay before restoring session at startup or the previous session. If the delay is too short, the computer might freeze.</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="restore_window_tiling_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox">
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkBox">
+                        <property name="margin_start">6</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_end">6</property>
+                        <property name="margin_bottom">6</property>
+                        <child>
+                          <object class="GtkLabel" id="restore_window_tiling_label">
+                            <property name="label" translatable="yes">Restore window tiling</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="restore_window_tiling_switch">
+                            <property name="focusable">1</property>
+                            <property name="active">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="hexpand">1</property>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkBox">
+                        <property name="margin_start">6</property>
+                        <property name="margin_end">6</property>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label" translatable="yes">Raise windows together</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="raise_windows_together_switch">
+                            <property name="focusable">1</property>
+                            <property name="active">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="hexpand">1</property>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkFrame" id="stash_and_restore_states_frame">
+            <property name="margin-top">30</property>
+            <property name="child">
+              <object class="GtkListBox">
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="focusable">1</property>
+                    <property name="child">
+                      <object class="GtkGrid">
+                        <property name="margin-bottom">12</property>
+                        <property name="margin_start">6</property>
+                        <property name="margin_end">6</property>
+                        <property name="margin_top">6</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">32</property>
+                        <child>
+                          <object class="GtkLabel" id="stash_and_restore_states_label">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Restore windows states after Gnome Shell restarts</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="stash_and_restore_states_switch">
+                            <property name="focusable">1</property>
+                            <property name="active">1</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="hexpand">1</property>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">0</property>
+                              <property name="row-span">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="hexpand">1</property>
+                            <property name="label" translatable="yes">Only enabled on X11, since Wayand doesn't support restart Gnome Shell via `Alt+F2 then type r` or `killall -3 gnome-shell`.</property>
+                            <property name="wrap">True</property>
+                            <property name="use-markup">1</property>
+                            <property name="xalign">0</property>
+                            <property name="valign">center</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">1</property>
+                            </layout>
+                          </object>
+                        </child>
+                      </object>
+                    </property>
+                  </object>
+                </child>
+              </object>
+            </property>
           </object>
         </child>
       </object>
@@ -803,150 +789,135 @@
   <object class="AdwPreferencesPage" id="general_page">
     <property name="icon-name">preferences-system-symbolic</property>
     <property name="use_underline">true</property>
-    <property name="margin_bottom">12</property>
-    <property name="margin_start">12</property>
-    <property name="margin_end">12</property>
     <property name="title" translatable="yes">General</property>
     <child>
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
+      <object class="AdwPreferencesGroup" id="general_group">
+        <property name="title" translatable="yes">General</property>
         <child>
-          <object class="GtkFrame">
-            <property name="margin-top">30</property>
-            <property name="margin-bottom">12</property>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkListBox">
-                <property name="selection-mode">none</property>
+              <object class="GtkFrame" id="show_indicator_frame">
                 <child>
-                  <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
-                    <property name="margin-top">12</property>
-                    <property name="margin-bottom">12</property>
-                    <property name="margin_start">6</property>
-                    <property name="margin_end">6</property>
-                    <property name="child">
-                      <object class="GtkBox">
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Show indicator on the panel</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">0</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="show_indicator_switch">
-                            <property name="focusable">1</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                            <layout>
-                              <property name="column">1</property>
-                              <property name="row">0</property>
-                            </layout>
-                          </object>
-                        </child>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkFrame" id="debugging_mode_frame">
-            <property name="child">
-              <object class="GtkListBox" id="debugging_mode_listbox">
-                <property name="selection-mode">none</property>
-                <child>
-                  <object class="GtkListBoxRow" id="debugging_mode_multi_row">
-                    <property name="focusable">1</property>
-                    <property name="child">
-                      <object class="GtkGrid" id="debugging_mode_multi_grid">
-                        <property name="margin-top">12</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="margin_start">6</property>
-                        <property name="margin_end">6</property>
-                        <property name="row-spacing">6</property>
-                        <property name="column-spacing">32</property>
-                        <child>
-                          <object class="GtkLabel" id="debugging_mode_label">
-                            <property name="hexpand">1</property>
-                            <property name="label" translatable="yes">Debugging mode</property>
-                            <property name="use-markup">1</property>
-                            <property name="xalign">0</property>
-                            <layout>
-                              <property name="column">0</property>
-                              <property name="row">0</property>
-                            </layout>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="debugging_mode_switch">
-                            <property name="focusable">1</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                            <layout>
-                              <property name="column">1</property>
-                              <property name="row">0</property>
-                            </layout>
-                          </object>
-                        </child>
-                      </object>
-                    </property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkListBox" id="verbose_logging_listbox">
+                  <object class="GtkListBox">
                     <property name="selection-mode">none</property>
                     <child>
-                      <object class="GtkListBoxRow" id="verbose_logging_row">
-                      <property name="focusable">1</property>
-                      <property name="child">
-                        <object class="GtkGrid" id="verbose_logging_grid">
-                        <property name="margin-bottom">12</property>
+                      <object class="GtkListBoxRow">
+                        <property name="focusable">1</property>
                         <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
                         <property name="margin_start">6</property>
                         <property name="margin_end">6</property>
-                        <property name="row-spacing">6</property>
-                        <property name="column-spacing">32</property>
-                        <child>
-                          <object class="GtkLabel" id="verbose_logging_label">
-                          <property name="hexpand">1</property>
-                          <property name="label" translatable="yes">Verbose logging</property>
-                          <property name="use-markup">1</property>
-                          <property name="xalign">0</property>
-                          <layout>
-                            <property name="column">0</property>
-                            <property name="row">0</property>
-                          </layout>
+                        <property name="child">
+                          <object class="GtkBox">
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Show indicator on the panel</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="show_indicator_switch">
+                                <property name="focusable">1</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                              </object>
+                            </child>
                           </object>
-                        </child>
-                        <child>
-                          <object class="GtkSwitch" id="verbose_logging_switch">
-                          <property name="focusable">1</property>
-                          <property name="halign">end</property>
-                          <property name="valign">center</property>
-                          <layout>
-                            <property name="column">1</property>
-                            <property name="row">0</property>
-                          </layout>
-                          </object>
-                        </child>
-                        </object>
-                      </property>
+                        </property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-            </property>
-            <child type="label_item">
-              <placeholder/>
+            </child>
+            <child>
+              <object class="GtkFrame" id="debugging_mode_frame">
+                <property name="margin-top">30</property>
+                <property name="child">
+                  <object class="GtkListBox" id="debugging_mode_listbox">
+                    <property name="selection-mode">none</property>
+                    <child>
+                      <object class="GtkListBoxRow" id="debugging_mode_multi_row">
+                        <property name="focusable">1</property>
+                        <property name="child">
+                          <object class="GtkGrid" id="debugging_mode_multi_grid">
+                            <property name="margin-top">12</property>
+                            <property name="margin-bottom">6</property>
+                            <property name="margin_start">6</property>
+                            <property name="margin_end">6</property>
+                            <property name="row-spacing">6</property>
+                            <property name="column-spacing">32</property>
+                            <child>
+                              <object class="GtkLabel" id="debugging_mode_label">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Debugging mode</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="debugging_mode_switch">
+                                <property name="focusable">1</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkListBoxRow" id="verbose_logging_row">
+                        <property name="focusable">1</property>
+                        <property name="child">
+                          <object class="GtkGrid" id="verbose_logging_grid">
+                            <property name="margin-bottom">12</property>
+                            <property name="margin-top">12</property>
+                            <property name="margin_start">6</property>
+                            <property name="margin_end">6</property>
+                            <property name="row-spacing">6</property>
+                            <property name="column-spacing">32</property>
+                            <child>
+                              <object class="GtkLabel" id="verbose_logging_label">
+                                <property name="hexpand">1</property>
+                                <property name="label" translatable="yes">Verbose logging</property>
+                                <property name="use-markup">1</property>
+                                <property name="xalign">0</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="verbose_logging_switch">
+                                <property name="focusable">1</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <layout>
+                                  <property name="column">1</property>
+                                  <property name="row">0</property>
+                                </layout>
+                              </object>
+                            </child>
+                          </object>
+                        </property>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
             </child>
           </object>
         </child>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -771,7 +771,7 @@
                         <child>
                           <object class="GtkLabel">
                             <property name="hexpand">true</property>
-                            <property name="label" translatable="yes">Only enabled on X11, since Wayand doesn't support restart Gnome Shell via `Alt+F2 then type r` or `killall -3 gnome-shell`.</property>
+                            <property name="label" translatable="yes">Only enabled on X11, since Wayland doesn't support restart Gnome Shell via `Alt+F2 then type r` or `killall -3 gnome-shell`.</property>
                             <property name="wrap">true</property>
                             <property name="use-markup">true</property>
                             <property name="xalign">0</property>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -39,6 +39,7 @@
           <object class="GtkFrame" id="close_windows_frame">
             <property name="child">
               <object class="GtkListBox">
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow" id="auto_close_session_multi_row">
                     <property name="focusable">1</property>
@@ -164,6 +165,7 @@
             <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox" id="close_by_rules_applications_list_box">
+                <property name="selection-mode">none</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="show-separators">True</property>
@@ -176,6 +178,7 @@
             <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox" id="close_by_rules_keywords_list_box">
+                <property name="selection-mode">none</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="show-separators">True</property>
@@ -188,6 +191,7 @@
             <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox" id="close_windows_whitelist_listbox">
+                <property name="selection-mode">none</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="show-separators">True</property>
@@ -209,6 +213,7 @@
           <object class="GtkFrame" id="save_session_notification_frame">
             <property name="child">
               <object class="GtkListBox">
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
                     <property name="focusable">1</property>
@@ -284,6 +289,7 @@
           <object class="GtkFrame" id="restore_previous_frame">
             <property name="child">
               <object class="GtkListBox">
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow" id="restore_previous_multi_row">
                     <property name="focusable">1</property>
@@ -405,6 +411,7 @@
             <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox">
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow" id="restore_at_startup_multi_row">
                     <property name="focusable">1</property>
@@ -534,6 +541,7 @@
             <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox">
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
                     <property name="focusable">1</property>
@@ -658,6 +666,7 @@
             <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox">
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
                     <property name="focusable">1</property>
@@ -721,6 +730,7 @@
             <property name="margin-top">30</property>
             <property name="child">
               <object class="GtkListBox">
+                <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
                     <property name="focusable">1</property>

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -42,7 +42,7 @@
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow" id="auto_close_session_multi_row">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid" id="auto_close_session_multi_grid1">
                         <property name="margin-top">12</property>
@@ -53,9 +53,9 @@
                         <property name="column-spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="auto_close_session_multi_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Auto close session</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -65,7 +65,7 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="auto_close_session_switch">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <layout>
@@ -77,10 +77,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="auto_close_session_multi_label_description">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Enable to close running apps and windows while Logout, Reboot and Shutdown via endSessionDialog.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -100,7 +100,7 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow" id="close_by_rules_multi_row">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid" id="close_by_rules_multi_grid1">
                         <property name="margin-top">12</property>
@@ -111,9 +111,9 @@
                         <property name="column-spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="close_by_rules_multi_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Close by rules</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -123,7 +123,7 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="close_by_rules_switch">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <layout>
@@ -135,10 +135,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="close_by_rules_multi_label_description">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">To make this feature work, see: &lt;a href='https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager#how-to-make-close-by-rules-work'&gt;How to make `Close by rules` work&lt;/a&gt;</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -166,9 +166,9 @@
             <property name="child">
               <object class="GtkListBox" id="close_by_rules_applications_list_box">
                 <property name="selection-mode">none</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <property name="show-separators">True</property>
+                <property name="hexpand">true</property>
+                <property name="vexpand">true</property>
+                <property name="show-separators">true</property>
               </object>
             </property>
           </object>
@@ -179,9 +179,9 @@
             <property name="child">
               <object class="GtkListBox" id="close_by_rules_keywords_list_box">
                 <property name="selection-mode">none</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <property name="show-separators">True</property>
+                <property name="hexpand">true</property>
+                <property name="vexpand">true</property>
+                <property name="show-separators">true</property>
               </object>
             </property>
           </object>
@@ -192,9 +192,9 @@
             <property name="child">
               <object class="GtkListBox" id="close_windows_whitelist_listbox">
                 <property name="selection-mode">none</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <property name="show-separators">True</property>
+                <property name="hexpand">true</property>
+                <property name="vexpand">true</property>
+                <property name="show-separators">true</property>
               </object>
             </property>
           </object>
@@ -216,7 +216,7 @@
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid">
                         <property name="margin-bottom">12</property>
@@ -226,9 +226,9 @@
                         <child>
                           <object class="GtkLabel" id="save_session_notification_label">
                             <property name="margin_top">12</property>
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Session is saved notification</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -239,11 +239,11 @@
                         <child>
                           <object class="GtkSwitch" id="save_session_notification_switch">
                             <property name="margin_end">6</property>
-                            <property name="focusable">1</property>
-                            <property name="active">1</property>
+                            <property name="focusable">true</property>
+                            <property name="active">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <layout>
                               <property name="column">1</property>
                               <property name="row">0</property>
@@ -253,10 +253,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Show a notification when users click buttons on the popup menu to save a session.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -292,7 +292,7 @@
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow" id="restore_previous_multi_row">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid">
                         <property name="margin-top">12</property>
@@ -302,9 +302,9 @@
                         <property name="margin_end">6</property>
                         <child>
                           <object class="GtkLabel">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Restore previous apps and windows at startup</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -314,7 +314,7 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="restore_previous_switch">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <layout>
@@ -326,10 +326,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Install ~/.config/autostart/_awsm-restore-previous-session.desktop if enabled</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -346,7 +346,7 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid" id="restore_previous_delay_multi_grid">
                         <property name="margin-bottom">12</property>
@@ -357,9 +357,9 @@
                         <property name="margin_end">12</property>
                         <child>
                           <object class="GtkLabel" id="restore_previous_delay_multi_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Restore delay([0, 3600]s)</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -369,10 +369,10 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="restore_previous_delay_spinbutton">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="text" translatable="yes">10</property>
                             <property name="adjustment">restore_previous_delay_adjustment</property>
-                            <property name="numeric">1</property>
+                            <property name="numeric">true</property>
                             <property name="value">10</property>
                             <property name="valign">center</property>
                             <layout>
@@ -384,10 +384,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">5 by default.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -414,7 +414,7 @@
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow" id="restore_at_startup_multi_row">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid" id="restore_at_startup_multi_grid">
                         <property name="margin-top">12</property>
@@ -425,9 +425,9 @@
                         <property name="margin_end">12</property>
                         <child>
                           <object class="GtkLabel" id="restore_at_startup_multi_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Restore selected session at startup</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -437,7 +437,7 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="restore_at_startup_switch">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <layout>
@@ -449,10 +449,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Install ~/.config/autostart/_gnome-shell-extension-another-window-session-manager.desktop if enabled</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -465,9 +465,9 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="restore_at_startup_without_asking_multi_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Restore at startup without asking</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -477,7 +477,7 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="restore_at_startup_without_asking_switch">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <layout>
@@ -488,9 +488,9 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="timer_on_the_autostart_dialog_multi_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Timer on the autostart dialog([0, 3600]s)</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -500,10 +500,10 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="timer_on_the_autostart_dialog_spinbutton">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="text" translatable="yes">10</property>
                             <property name="adjustment">timer_on_the_autostart_dialog_adjustment</property>
-                            <property name="numeric">1</property>
+                            <property name="numeric">true</property>
                             <property name="value">10</property>
                             <layout>
                               <property name="column">1</property>
@@ -514,10 +514,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">10 by default.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -544,7 +544,7 @@
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid">
                         <property name="margin-top">12</property>
@@ -554,9 +554,9 @@
                         <property name="margin_end">12</property>
                         <child>
                           <object class="GtkLabel" id="restore_session_interval_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Restore applications interval([0, 300000]ms)</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -566,10 +566,10 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="restore_session_interval_spinbutton">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="text" translatable="yes">10</property>
                             <property name="adjustment">restore_session_interval_spinbutton_adjustment</property>
-                            <property name="numeric">1</property>
+                            <property name="numeric">true</property>
                             <property name="value">0</property>
                             <property name="valign">center</property>
                             <layout>
@@ -581,10 +581,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="restore_session_interval_label_description">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">0 by default. There's no need to set this option normally, unless the process of restoring session is too fast to freeze the system, for example.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -601,7 +601,7 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid">
                         <property name="margin-bottom">12</property>
@@ -612,9 +612,9 @@
                         <property name="margin_end">6</property>
                         <child>
                           <object class="GtkLabel" id="autostart_delay_multi_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Autostart delay([0, 3600]s)</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -624,10 +624,10 @@
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="autostart_delay_spinbutton">
-                            <property name="focusable">1</property>
+                            <property name="focusable">true</property>
                             <property name="text" translatable="yes">20</property>
                             <property name="adjustment">autostart_delay_adjustment</property>
-                            <property name="numeric">1</property>
+                            <property name="numeric">true</property>
                             <property name="value">20</property>
                             <property name="valign">center</property>
                             <layout>
@@ -639,10 +639,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel" id="autostart_delay_multi_label_description">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">5 by default. Delay before restoring session at startup or the previous session. If the delay is too short, the computer might freeze.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <style>
                               <class name="dim-label"/>
@@ -669,7 +669,7 @@
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkBox">
                         <property name="margin_start">6</property>
@@ -683,11 +683,11 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="restore_window_tiling_switch">
-                            <property name="focusable">1</property>
-                            <property name="active">1</property>
+                            <property name="focusable">true</property>
+                            <property name="active">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                           </object>
                         </child>
                       </object>
@@ -696,7 +696,7 @@
                 </child>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkBox">
                         <property name="margin_start">6</property>
@@ -710,11 +710,11 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="raise_windows_together_switch">
-                            <property name="focusable">1</property>
-                            <property name="active">1</property>
+                            <property name="focusable">true</property>
+                            <property name="active">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                           </object>
                         </child>
                       </object>
@@ -733,7 +733,7 @@
                 <property name="selection-mode">none</property>
                 <child>
                   <object class="GtkListBoxRow">
-                    <property name="focusable">1</property>
+                    <property name="focusable">true</property>
                     <property name="child">
                       <object class="GtkGrid">
                         <property name="margin-bottom">12</property>
@@ -744,9 +744,9 @@
                         <property name="column-spacing">32</property>
                         <child>
                           <object class="GtkLabel" id="stash_and_restore_states_label">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Restore windows states after Gnome Shell restarts</property>
-                            <property name="use-markup">1</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <layout>
                               <property name="column">0</property>
@@ -756,11 +756,11 @@
                         </child>
                         <child>
                           <object class="GtkSwitch" id="stash_and_restore_states_switch">
-                            <property name="focusable">1</property>
-                            <property name="active">1</property>
+                            <property name="focusable">true</property>
+                            <property name="active">true</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <layout>
                               <property name="column">1</property>
                               <property name="row">0</property>
@@ -770,10 +770,10 @@
                         </child>
                         <child>
                           <object class="GtkLabel">
-                            <property name="hexpand">1</property>
+                            <property name="hexpand">true</property>
                             <property name="label" translatable="yes">Only enabled on X11, since Wayand doesn't support restart Gnome Shell via `Alt+F2 then type r` or `killall -3 gnome-shell`.</property>
-                            <property name="wrap">True</property>
-                            <property name="use-markup">1</property>
+                            <property name="wrap">true</property>
+                            <property name="use-markup">true</property>
                             <property name="xalign">0</property>
                             <property name="valign">center</property>
                             <style>
@@ -813,7 +813,7 @@
                     <property name="selection-mode">none</property>
                     <child>
                       <object class="GtkListBoxRow">
-                        <property name="focusable">1</property>
+                        <property name="focusable">true</property>
                         <property name="margin-top">12</property>
                         <property name="margin-bottom">12</property>
                         <property name="margin_start">6</property>
@@ -822,15 +822,15 @@
                           <object class="GtkBox">
                             <child>
                               <object class="GtkLabel">
-                                <property name="hexpand">1</property>
+                                <property name="hexpand">true</property>
                                 <property name="label" translatable="yes">Show indicator on the panel</property>
-                                <property name="use-markup">1</property>
+                                <property name="use-markup">true</property>
                                 <property name="xalign">0</property>
                               </object>
                             </child>
                             <child>
                               <object class="GtkSwitch" id="show_indicator_switch">
-                                <property name="focusable">1</property>
+                                <property name="focusable">true</property>
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
                               </object>
@@ -851,7 +851,7 @@
                     <property name="selection-mode">none</property>
                     <child>
                       <object class="GtkListBoxRow" id="debugging_mode_multi_row">
-                        <property name="focusable">1</property>
+                        <property name="focusable">true</property>
                         <property name="child">
                           <object class="GtkGrid" id="debugging_mode_multi_grid">
                             <property name="margin-top">12</property>
@@ -862,9 +862,9 @@
                             <property name="column-spacing">32</property>
                             <child>
                               <object class="GtkLabel" id="debugging_mode_label">
-                                <property name="hexpand">1</property>
+                                <property name="hexpand">true</property>
                                 <property name="label" translatable="yes">Debugging mode</property>
-                                <property name="use-markup">1</property>
+                                <property name="use-markup">true</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -874,7 +874,7 @@
                             </child>
                             <child>
                               <object class="GtkSwitch" id="debugging_mode_switch">
-                                <property name="focusable">1</property>
+                                <property name="focusable">true</property>
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
                                 <layout>
@@ -889,7 +889,7 @@
                     </child>
                     <child>
                       <object class="GtkListBoxRow" id="verbose_logging_row">
-                        <property name="focusable">1</property>
+                        <property name="focusable">true</property>
                         <property name="child">
                           <object class="GtkGrid" id="verbose_logging_grid">
                             <property name="margin-bottom">12</property>
@@ -900,9 +900,9 @@
                             <property name="column-spacing">32</property>
                             <child>
                               <object class="GtkLabel" id="verbose_logging_label">
-                                <property name="hexpand">1</property>
+                                <property name="hexpand">true</property>
                                 <property name="label" translatable="yes">Verbose logging</property>
-                                <property name="use-markup">1</property>
+                                <property name="use-markup">true</property>
                                 <property name="xalign">0</property>
                                 <layout>
                                   <property name="column">0</property>
@@ -912,7 +912,7 @@
                             </child>
                             <child>
                               <object class="GtkSwitch" id="verbose_logging_switch">
-                                <property name="focusable">1</property>
+                                <property name="focusable">true</property>
                                 <property name="halign">end</property>
                                 <property name="valign">center</property>
                                 <layout>


### PR DESCRIPTION
- Using AdwPreferencesGroup instead of Gtk UI-Widgets now
- Fixed attempting to run a JS callback during shutdown
- Not using deprecated Gio.DesktopAppInfo anymore