### PR TITLE
Fix status indicator conflict after screen lock/unlock cycle

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -35,7 +35,7 @@ export default class AnotherWindowSessionManagerExtension extends Extension {
 
         this.initUtils();
         
-        this._settings.connect('changed::show-indicator', () => this.showOrHideIndicator());
+        this._settingsChangedId = this._settings.connect('changed::show-indicator', () => this.showOrHideIndicator());
         this.showOrHideIndicator();
     
         _autostartServiceProvider = new Autostart.AutostartServiceProvider();
@@ -57,6 +57,12 @@ export default class AnotherWindowSessionManagerExtension extends Extension {
     showOrHideIndicator() {
         if (this._settings.get_boolean('show-indicator')) {
             if (!_indicator) {
+                // Remove any stale indicator left over from a previous enable/disable cycle
+                // (e.g. after screen lock/unlock) to avoid "Extension point conflict" error
+                const existingIndicator = Main.panel.statusArea['Another Window Session Manager'];
+                if (existingIndicator) {
+                    existingIndicator.destroy();
+                }
                 _indicator = new Indicator.AwsIndicator();
                 Main.panel.addToStatusArea('Another Window Session Manager', _indicator);
             }
@@ -101,6 +107,10 @@ export default class AnotherWindowSessionManagerExtension extends Extension {
         }
 
         if (this._settings) {
+            if (this._settingsChangedId) {
+                this._settings.disconnect(this._settingsChangedId);
+                this._settingsChangedId = null;
+            }
             this._settings = null;
         }
 


### PR DESCRIPTION
## Summary

Fixes the "Extension point conflict" error that causes the extension to fail to load after every screen lock/unlock or suspend/resume cycle.

## The problem

When the screen is locked and unlocked, GNOME Shell calls `disable()` then `enable()` on all extensions. The current code in `disable()` calls `hideIndicator()`, which does:

```js
_indicator.destroy();
_indicator = null;
```

On the next `enable()`, `_indicator` is `null`, so `showOrHideIndicator()` creates a new indicator and calls:

```js
Main.panel.addToStatusArea('Another Window Session Manager', _indicator);
```

However, `addToStatusArea()` throws an error:

```
Extension another-window-session-manager@gmail.com: Error: Extension point conflict:
there is already a status indicator for role Another Window Session Manager
```

### Why this happens

The GNOME Shell panel internally tracks status indicators by their role name. During a rapid `disable()`/`enable()` cycle (as happens on screen lock/unlock), the panel's internal `statusArea` registry may still hold a reference to the old indicator role even after `destroy()` has been called. This is because `destroy()` is asynchronous in GObject — the actual cleanup happens in the next main loop iteration, but `enable()` is called synchronously right after `disable()`.

This causes the extension to **completely fail to load** after every lock/unlock, which is a significant usability issue.

### Additional issue: signal handler leak

Line 38 connects a signal handler on every `enable()` call:

```js
this._settings.connect('changed::show-indicator', () => this.showOrHideIndicator());
```

But this handler is **never disconnected** in `disable()`. Each lock/unlock cycle adds another handler, leaking signal connections over time.

## Changes

### 1. Clean up stale status indicator before registering (root cause fix)

Before calling `addToStatusArea()`, check if a stale indicator already exists in `Main.panel.statusArea` and destroy it:

```js
const existingIndicator = Main.panel.statusArea['Another Window Session Manager'];
if (existingIndicator) {
    existingIndicator.destroy();
}
```

This ensures the role is free before registering, regardless of the timing of GObject destruction.

### 2. Disconnect settings signal handler in `disable()` (leak fix)

Store the signal connection ID and disconnect it properly:

```js
// In enable():
this._settingsChangedId = this._settings.connect('changed::show-indicator', ...);

// In disable():
this._settings.disconnect(this._settingsChangedId);
```

## Environment

- GNOME Shell 46.0 (Ubuntu 24.04 noble, Wayland)
- Extension version 51

## Test plan

- [ ] Verify extension loads correctly after a fresh login
- [ ] Lock and unlock the screen — extension should still be active with its indicator
- [ ] Suspend and resume — extension should still work
- [ ] Toggle the `show-indicator` setting — indicator appears/disappears correctly
- [ ] Repeat lock/unlock multiple times — no accumulated errors in journal

## Note

The same bug exists in the `main-gnome-47-48` branch (identical code). A separate PR or cherry-pick would be needed there.