### PR TITLE
Fix D-Bus export conflicts after disable/enable cycle

### DIFF
--- a/ui/autostart.js
+++ b/ui/autostart.js
@@ -74,11 +74,24 @@ export const AutostartServiceProvider = GObject.registerClass(
         }
 
         disable() {
-            // To avoid the below error
-            // JS ERROR: Gio.IOErrorEnum: An object is already exported for the interface org.gnome.Shell.Extensions.awsm.Autostart at /org/gnome/Shell/Extensions/awsm
-            // when disable and enable this extension
-            this._autostartDbusImpl.flush();
-            this._autostartDbusImpl.unexport();
+            // Unexport the D-Bus interface to avoid:
+            //   Gio.IOErrorEnum: An object is already exported for the interface
+            //   org.gnome.Shell.Extensions.awsm.Autostart at /org/gnome/Shell/Extensions/awsm
+            // when the extension is disabled and re-enabled (e.g. suspend/resume cycle).
+            //
+            // _autostartDbusImpl may be null if onBusAcquired() hasn't been called yet
+            // (race condition during rapid disable after enable).
+            if (this._autostartDbusImpl) {
+                this._autostartDbusImpl.flush();
+                this._autostartDbusImpl.unexport();
+                this._autostartDbusImpl = null;
+            }
+
+            // Release the D-Bus name so the next enable() can re-acquire it cleanly
+            if (this._dbusNameOwnerId) {
+                Gio.bus_unown_name(this._dbusNameOwnerId);
+                this._dbusNameOwnerId = 0;
+            }
 
             if (this._autostartService) {
                 this._autostartService._disable();

--- a/utils/WindowPicker.js
+++ b/utils/WindowPicker.js
@@ -110,12 +110,27 @@ export const WindowPickerServiceProvider = class WindowPickerServiceProvider {
 
   // Call this to make the window-picking API available on the D-Bus.
   enable() {
+    // Defensively unexport first: after a rapid disable/enable cycle (e.g.
+    // suspend/resume, screen lock/unlock), the previous export may still be
+    // registered.  Calling unexport() on an already-unexported object is
+    // harmless, but calling export() on an already-exported path throws:
+    //   Gio.IOErrorEnum: An object is already exported for the interface
+    //   org.gnome.Shell.Extensions.awsm.PickWindow at /org/gnome/shell/extensions/awsm
+    try {
+      this._dbus.unexport();
+    } catch (_e) {
+      // Not exported yet — expected on first enable()
+    }
     this._dbus.export(Gio.DBus.session, '/org/gnome/shell/extensions/awsm');
   }
 
   // Call this to stop this D-Bus again.
   destroy() {
-    this._dbus.unexport();
+    try {
+      this._dbus.unexport();
+    } catch (_e) {
+      // Already unexported — not an error
+    }
   }
 };
 


### PR DESCRIPTION
## Problem

After a rapid `disable()` → `enable()` cycle (triggered by suspend/resume, screen lock/unlock, or monitor reconfiguration on GNOME Shell 46), the extension crashes with **two D-Bus errors** and enters ERROR state (state 3). Recovery requires a full GNOME Shell restart (logout/login on Wayland).

### Error 1 — PickWindow interface

```
Gio.IOErrorEnum: An object is already exported for the interface
  "org.gnome.Shell.Extensions.awsm.PickWindow" at "/org/gnome/shell/extensions/awsm"
```

**Root cause:** `WindowPickerServiceProvider.enable()` calls `this._dbus.export()` without checking if the interface is already exported. During a rapid disable/enable cycle, `destroy()`'s `unexport()` may not have fully completed before the next `enable()` re-exports on the same path.

### Error 2 — Autostart interface

```
TypeError: this._autostartDbusImpl is null
```

**Root cause:** `AutostartServiceProvider.disable()` calls `this._autostartDbusImpl.flush()` and `.unexport()` without a null guard. `_autostartDbusImpl` is set in `onBusAcquired()`, which is an async callback — if `disable()` is called before the bus is acquired (race condition during rapid cycling), it's still `null`.

Additionally, `disable()` never calls `Gio.bus_unown_name()`, so the D-Bus name ownership (`org.gnome.Shell.Extensions.awsm`) leaks across disable/enable cycles, preventing the next `_init()` from cleanly re-acquiring it.

## Fix

### `utils/WindowPicker.js`
- `enable()`: defensively call `unexport()` before `export()` to clear any stale registration
- `destroy()`: wrap `unexport()` in try/catch (idempotent — safe if already unexported)

### `ui/autostart.js`
- `disable()`: add null guard on `_autostartDbusImpl` before calling `flush()`/`unexport()`
- `disable()`: call `Gio.bus_unown_name(this._dbusNameOwnerId)` to release the D-Bus name, so the next `enable()` → `_init()` → `bus_own_name()` can re-acquire it cleanly
- Set `_autostartDbusImpl = null` and `_dbusNameOwnerId = 0` after cleanup

## Context

This is particularly problematic on Ubuntu 24.04 (GNOME Shell 46, Wayland) where a known gnome-shell bug causes all extensions to be disabled and re-enabled during:
- Suspend/resume (lid close/open)
- Screen lock/unlock
- Monitor reconfiguration (external display plug/unplug)

Without this fix, the extension enters ERROR state after every such event and never recovers until the next login.

## Testing

Tested on GNOME Shell 46.0, Ubuntu 24.04, Wayland:
1. Enable extension → suspend → resume → extension stays in ENABLED state (state 1)
2. Enable extension → lock screen → unlock → extension stays in ENABLED state
3. Rapid manual `gnome-extensions disable` / `gnome-extensions enable` cycling → no errors

## Related

This is a separate issue from #128 (status indicator "Extension point conflict"), which was fixed in PR #129. That PR addresses the `Main.panel.statusArea` conflict; this PR addresses the D-Bus interface export conflicts.