### PR TITLE
Handle multi-window applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 .history
 .idea
+.claude

--- a/closeSession.js
+++ b/closeSession.js
@@ -486,10 +486,15 @@ export const CloseSession = class {
         }
 
         let windows;
-        if (Meta.is_wayland_compositor()) {
+
+        if (Constants.shellVersion >= 50) {
             windows = this._sortWindowsOnWayland(app);
         } else {
-            windows = this._sortWindowsOnX11(app);
+            if (Meta.is_wayland_compositor()) {
+                windows = this._sortWindowsOnWayland(app);
+            } else {
+                windows = this._sortWindowsOnX11(app);
+            }
         }
         return windows;
     }

--- a/indicator.js
+++ b/indicator.js
@@ -80,48 +80,50 @@ class AwsIndicator extends PanelMenu.Button {
 
     // TODO Move this method and related code to a single .js file
     async _windowCreated(display, metaWindow, userData) {
-        if (!Meta.is_wayland_compositor()) {
-            // We call createEnoughWorkspaceAndMoveWindows() if and only if all conditions checked.
-            
-            // But we give some windows (such as the OS running in VirtualBox) a chance to connect `first-frame` and `shown` signals.
-            // The reason I do this is that 
-            // `Shell.AppSystem.get_default().lookup_app('a-VirtualBox-machine-name.desktop')`
-            // and `Shell.WindowTracker.get_default().get_window_app(metaWindow_of_VirtualBoxMachine)`
-            // are not the same instance. 
-            
-            // My best guess is:
-            // Looks like if launch a VirtualBox machine via `/usr/lib64/virtualbox/VirtualBoxVM --comment "test" --startvm "{xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxxxxxxxxx}"`,
-            // it will open two process: the first process open another process, which is running a machine, and then the first process stops to run and the associated Shell.App is also destroyed.
-            // And
-            // the two processes all have window, window of the first process will be destroyed before/after the second process open a new window, which is running the virtual OS.
-            // Install https://extensions.gnome.org/extension/4679/burn-my-windows/ to watch this process.
+        if (Constants.shellVersion < 50) {
+            if (!Meta.is_wayland_compositor()) {
+                // We call createEnoughWorkspaceAndMoveWindows() if and only if all conditions checked.
 
-            const shellApp = this._windowTracker.get_window_app(metaWindow);
-            let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
-            if (!shellAppData) {
-                shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
-            }
+                // But we give some windows (such as the OS running in VirtualBox) a chance to connect `first-frame` and `shown` signals.
+                // The reason I do this is that
+                // `Shell.AppSystem.get_default().lookup_app('a-VirtualBox-machine-name.desktop')`
+                // and `Shell.WindowTracker.get_window_app(metaWindow_of_VirtualBoxMachine)`
+                // are not the same instance.
 
-            if (shellAppData) {
-                const saved_window_sessions = shellAppData.saved_window_sessions;
+                // My best guess is:
+                // Looks like if launch a VirtualBox machine via `/usr/lib64/virtualbox/VirtualBoxVM --comment "test" --startvm "{xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxxxxxxxxx}"`,
+                // it will open two process: the first process open another process, which is running a machine, and then the first process stops to run and the associated Shell.App is also destroyed.
+                // And
+                // the two processes all have window, window of the first process will be destroyed before/after the second process open a new window, which is running the virtual OS.
+                // Install https://extensions.gnome.org/extension/4679/burn-my-windows/ to watch this process.
 
-                // On X11, we have to create enough workspace and move windows before receive the first-frame signal.
-                // If not, all windows will be shown in current workspace when stay in Overview, which is not pretty.
-                let matchedSavedWindowSession = await this._moveSession.createEnoughWorkspaceAndMoveWindows(metaWindow, saved_window_sessions);
-                
-                if (matchedSavedWindowSession) {
-                    // We try to restore window state here if necessary.
-                    // Below are possible reasons:
-                    // 1) In current implement there is no guarantee that the first-frame and shown signals can be triggered immediately. You have to click a window to trigger them.
-                    // 2) The restored window state could be lost
-                    this._log.debug(`Restoring window state of ${shellApp.get_name()} - ${metaWindow.get_title()} if necessary`);
-                    this._moveSession._restoreWindowState(metaWindow, matchedSavedWindowSession);
+                const shellApp = this._windowTracker.get_window_app(metaWindow);
+                let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
+                if (!shellAppData) {
+                    shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
+                }
+
+                if (shellAppData) {
+                    const saved_window_sessions = shellAppData.saved_window_sessions;
+
+                    // On X11, we have to create enough workspace and move windows before receive the first-frame signal.
+                    // If not, all windows will be shown in current workspace when stay in Overview, which is not pretty.
+                    let matchedSavedWindowSession = await this._moveSession.createEnoughWorkspaceAndMoveWindows(metaWindow, saved_window_sessions);
+
+                    if (matchedSavedWindowSession) {
+                        // We try to restore window state here if necessary.
+                        // Below are possible reasons:
+                        // 1) In current implement there is no guarantee that the first-frame and shown signals can be triggered immediately. You have to click a window to trigger them.
+                        // 2) The restored window state could be lost
+                        this._log.debug(`Restoring window state of ${shellApp.get_name()} - ${metaWindow.get_title()} if necessary`);
+                        this._moveSession._restoreWindowState(metaWindow, matchedSavedWindowSession);
 
 
-                    // Fix window geometry later on in first-frame signal
-                    // TODO The side-effect is when a window is already in the current workspace there will be two same logs (The window 'Clocks' is already on workspace 0 for Clocks) in the journalctl, which is not pretty.
-                    // TODO Maybe it's better to use another state to indicator whether a window has been restored geometry.
-                    matchedSavedWindowSession.moved = false;
+                        // Fix window geometry later on in first-frame signal
+                        // TODO The side-effect is when a window is already in the current workspace there will be two same logs (The window 'Clocks' is already on workspace 0 for Clocks) in the journalctl, which is not pretty.
+                        // TODO Maybe it's better to use another state to indicator whether a window has been restored geometry.
+                        matchedSavedWindowSession.moved = false;
+                    }
                 }
             }
         }

--- a/metadata.json
+++ b/metadata.json
@@ -11,5 +11,5 @@
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 53
+    "version": 54
   }

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
       "46",
       "47",
       "48",
-      "49"
+      "49",
+      "50"
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",

--- a/model/sessionConfig.js
+++ b/model/sessionConfig.js
@@ -85,6 +85,8 @@ export const SessionConfigObject = class {
 
     is_focused; // boolean, whether is the currently active window
 
+    window_hash; // string. Hash for matching windows across sessions: "wm_class|desktop_number|x|y"
+
     compositor_type; // string. X11, Wayland
 }
 

--- a/moveSession.js
+++ b/moveSession.js
@@ -32,6 +32,13 @@ export const MoveSession = class {
 
     }
 
+    _computeWindowHash(metaWindow) {
+        const wm_class = metaWindow.get_wm_class();
+        const desktop_number = metaWindow.get_workspace().index();
+        const frameRect = metaWindow.get_frame_rect();
+        return `${wm_class}|${desktop_number}|${frameRect.x}|${frameRect.y}`;
+    }
+
     async moveWindows(sessionName) {
         if (!sessionName) {
             sessionName = this.sessionName;
@@ -271,24 +278,44 @@ export const MoveSession = class {
             return !saved_window_session.moved;
         });
 
+        const currentHash = this._computeWindowHash(metaWindow);
+        this._log.debug(`Matching window hash: ${currentHash} (${metaWindow.get_title()})`);
+
         for (const saved_window_session of saved_window_sessions) {
-            const title = metaWindow.get_title();
-            const windows_count = saved_window_session.windows_count;
             const open_window_workspace_index = metaWindow.get_workspace().index();
             const desktop_number = saved_window_session.desktop_number;
 
-            if (windows_count === 1 || title === saved_window_session.window_title) {
-                if (open_window_workspace_index === desktop_number) {
-                    if (this._log.isDebug()) {
-                        const shellApp = this._windowTracker.get_window_app(metaWindow);
-                        this._log.debug(`The window '${shellApp?.get_name()} - ${title}' is already on workspace ${desktop_number}`);
+            // Match by hash if available, fall back to old logic for backward compatibility
+            if (saved_window_session.window_hash) {
+                if (currentHash === saved_window_session.window_hash) {
+                    this._log.debug(`Hash match: ${currentHash}`);
+                    if (open_window_workspace_index === desktop_number) {
+                        if (this._log.isDebug()) {
+                            const shellApp = this._windowTracker.get_window_app(metaWindow);
+                            this._log.debug(`The window '${shellApp?.get_name()} - ${metaWindow.get_title()}' is already on workspace ${desktop_number}`);
+                        }
+                        saved_window_session.moved = true;
                     }
-                    saved_window_session.moved = true;
+                    return saved_window_session;
                 }
-
-                return saved_window_session;
+            } else {
+                // Backward compatibility: old sessions without window_hash
+                const title = metaWindow.get_title();
+                const windows_count = saved_window_session.windows_count;
+                if (windows_count === 1 || title === saved_window_session.window_title) {
+                    if (open_window_workspace_index === desktop_number) {
+                        if (this._log.isDebug()) {
+                            const shellApp = this._windowTracker.get_window_app(metaWindow);
+                            this._log.debug(`The window '${shellApp?.get_name()} - ${metaWindow.get_title()}' is already on workspace ${desktop_number}`);
+                        }
+                        saved_window_session.moved = true;
+                    }
+                    return saved_window_session;
+                }
             }
         }
+
+        this._log.debug(`No match found for hash: ${currentHash}`);
         return null;
     }
 
@@ -446,20 +473,32 @@ export const MoveSession = class {
 
         let autoMoveInterestingWindows = [];
         const open_windows = shellApp.get_windows();
-        saved_window_sessions.forEach(saved_window_session => {
-            open_windows.forEach(open_window => {
+        for (const saved_window_session of saved_window_sessions) {
+            for (const open_window of open_windows) {
                 if (open_window.get_wm_class() != saved_window_session.wm_class) {
-                    return;
+                    continue;
                 }
 
-                const title = open_window.get_title();
-                const windows_count = saved_window_session.windows_count;
                 const open_window_workspace_index = open_window.get_workspace().index();
                 const desktop_number = saved_window_session.desktop_number;
 
-                if (windows_count === 1 || title === saved_window_session.window_title) {
+                let matched = false;
+                if (saved_window_session.window_hash) {
+                    const currentHash = this._computeWindowHash(open_window);
+                    matched = (currentHash === saved_window_session.window_hash);
+                    if (matched) {
+                        this._log.debug(`Auto-move hash match: ${currentHash} for ${shellApp.get_name()}`);
+                    }
+                } else {
+                    // Backward compatibility
+                    const title = open_window.get_title();
+                    const windows_count = saved_window_session.windows_count;
+                    matched = (windows_count === 1 || title === saved_window_session.window_title);
+                }
+
+                if (matched) {
                     if (open_window_workspace_index === desktop_number) {
-                        this._log.debug(`The window '${title}' is already on workspace ${desktop_number} for ${shellApp.get_name()}`);
+                        this._log.debug(`The window '${open_window.get_title()}' is already on workspace ${desktop_number} for ${shellApp.get_name()}`);
                         this._restoreWindowStates(open_window, saved_window_session, true);
                     } else {
                         autoMoveInterestingWindows.push({
@@ -467,11 +506,10 @@ export const MoveSession = class {
                             saved_window_session: saved_window_session
                         });
                     }
+                    break; // This saved_window_session is matched, move to next one
                 }
-
-            });
-
-        });
+            }
+        }
 
         return autoMoveInterestingWindows;
     }

--- a/moveSession.js
+++ b/moveSession.js
@@ -39,6 +39,27 @@ export const MoveSession = class {
         return `${wm_class}|${desktop_number}|${frameRect.x}|${frameRect.y}`;
     }
 
+    /**
+     * Compute a position-only hash (without workspace) for matching windows
+     * that may be on the wrong workspace. Used by the "move windows" feature
+     * where the whole point is that windows need to change workspace.
+     */
+    _computePositionHash(metaWindow) {
+        const wm_class = metaWindow.get_wm_class();
+        const frameRect = metaWindow.get_frame_rect();
+        return `${wm_class}|${frameRect.x}|${frameRect.y}`;
+    }
+
+    /**
+     * Extract a position-only hash from a saved window_hash by stripping
+     * the desktop_number component (format: wm_class|desktop|x|y -> wm_class|x|y)
+     */
+    _savedHashToPositionHash(savedHash) {
+        const parts = savedHash.split('|');
+        // Remove the desktop_number (index 1)
+        return `${parts[0]}|${parts[2]}|${parts[3]}`;
+    }
+
     async moveWindows(sessionName) {
         if (!sessionName) {
             sessionName = this.sessionName;
@@ -110,8 +131,9 @@ export const MoveSession = class {
                         this._changeWorkspace(metaWindow, desktop_number);
                     }
     
-                    // restore window state if necessary due to moving windows could lost window state
+                    // restore window state and geometry after moving, since workspace change can reset both
                     this._restoreWindowState(metaWindow, saved_window_session);
+                    this._restoreWindowGeometry(metaWindow, saved_window_session);
     
                 } catch (e) {
                     // I just don't want one failure breaks the loop
@@ -254,8 +276,9 @@ export const MoveSession = class {
                     this._log.debug(`MWMW: Moving ${shellApp?.get_name()} - ${metaWindow.get_title()} to workspace ${desktop_number} from ${metaWindow.get_workspace().index()}`);
                     this._changeWorkspace(metaWindow, desktop_number);
                 }
-                // The window state get lost during moving the window, and we need to restore window state again.
+                // The window state and geometry get lost during moving the window, restore both again.
                 this._restoreWindowState(metaWindow, saved_window_session);
+                this._restoreWindowGeometry(metaWindow, saved_window_session);
 
                 saved_window_session.moved = true;
             }
@@ -278,44 +301,44 @@ export const MoveSession = class {
             return !saved_window_session.moved;
         });
 
-        const currentHash = this._computeWindowHash(metaWindow);
-        this._log.debug(`Matching window hash: ${currentHash} (${metaWindow.get_title()})`);
+        const currentPositionHash = this._computePositionHash(metaWindow);
+        this._log.debug(`Matching window position hash: ${currentPositionHash} (${metaWindow.get_title()})`);
 
         for (const saved_window_session of saved_window_sessions) {
             const open_window_workspace_index = metaWindow.get_workspace().index();
             const desktop_number = saved_window_session.desktop_number;
 
-            // Match by hash if available, fall back to old logic for backward compatibility
+            // Try position hash first (best precision, works when windows are at saved positions)
+            let matched = false;
             if (saved_window_session.window_hash) {
-                if (currentHash === saved_window_session.window_hash) {
-                    this._log.debug(`Hash match: ${currentHash}`);
-                    if (open_window_workspace_index === desktop_number) {
-                        if (this._log.isDebug()) {
-                            const shellApp = this._windowTracker.get_window_app(metaWindow);
-                            this._log.debug(`The window '${shellApp?.get_name()} - ${metaWindow.get_title()}' is already on workspace ${desktop_number}`);
-                        }
-                        saved_window_session.moved = true;
-                    }
-                    return saved_window_session;
+                const savedPositionHash = this._savedHashToPositionHash(saved_window_session.window_hash);
+                if (currentPositionHash === savedPositionHash) {
+                    this._log.debug(`Position hash match: ${currentPositionHash} -> workspace ${desktop_number}`);
+                    matched = true;
                 }
-            } else {
-                // Backward compatibility: old sessions without window_hash
+            }
+            // Fall back to title/count matching (works after login when windows are at default positions)
+            if (!matched) {
                 const title = metaWindow.get_title();
                 const windows_count = saved_window_session.windows_count;
                 if (windows_count === 1 || title === saved_window_session.window_title) {
-                    if (open_window_workspace_index === desktop_number) {
-                        if (this._log.isDebug()) {
-                            const shellApp = this._windowTracker.get_window_app(metaWindow);
-                            this._log.debug(`The window '${shellApp?.get_name()} - ${metaWindow.get_title()}' is already on workspace ${desktop_number}`);
-                        }
-                        saved_window_session.moved = true;
-                    }
-                    return saved_window_session;
+                    this._log.debug(`Title/count fallback match: ${metaWindow.get_title()} -> workspace ${desktop_number}`);
+                    matched = true;
                 }
+            }
+            if (matched) {
+                if (open_window_workspace_index === desktop_number) {
+                    if (this._log.isDebug()) {
+                        const shellApp = this._windowTracker.get_window_app(metaWindow);
+                        this._log.debug(`The window '${shellApp?.get_name()} - ${metaWindow.get_title()}' is already on workspace ${desktop_number}`);
+                    }
+                    saved_window_session.moved = true;
+                }
+                return saved_window_session;
             }
         }
 
-        this._log.debug(`No match found for hash: ${currentHash}`);
+        this._log.debug(`No match found for position hash: ${currentPositionHash}`);
         return null;
     }
 
@@ -483,17 +506,23 @@ export const MoveSession = class {
                 const desktop_number = saved_window_session.desktop_number;
 
                 let matched = false;
+                // Try position hash first (best precision, works when windows are at saved positions)
                 if (saved_window_session.window_hash) {
-                    const currentHash = this._computeWindowHash(open_window);
-                    matched = (currentHash === saved_window_session.window_hash);
+                    const currentPositionHash = this._computePositionHash(open_window);
+                    const savedPositionHash = this._savedHashToPositionHash(saved_window_session.window_hash);
+                    matched = (currentPositionHash === savedPositionHash);
                     if (matched) {
-                        this._log.debug(`Auto-move hash match: ${currentHash} for ${shellApp.get_name()}`);
+                        this._log.debug(`Auto-move position hash match: ${currentPositionHash} for ${shellApp.get_name()}`);
                     }
-                } else {
-                    // Backward compatibility
+                }
+                // Fall back to title/count matching (works after login when windows are at default positions)
+                if (!matched) {
                     const title = open_window.get_title();
                     const windows_count = saved_window_session.windows_count;
                     matched = (windows_count === 1 || title === saved_window_session.window_title);
+                    if (matched) {
+                        this._log.debug(`Auto-move title/count fallback match: ${open_window.get_title()} for ${shellApp.get_name()}`);
+                    }
                 }
 
                 if (matched) {

--- a/moveSession.js
+++ b/moveSession.js
@@ -7,12 +7,13 @@ import Meta from 'gi://Meta';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
+import * as Constants from './constants.js';
+
 import * as UiHelper from './ui/uiHelper.js';
 
 import * as FileUtils from './utils/fileUtils.js';
 import * as Log from './utils/log.js';
 import * as DateUtils from './utils/dateUtils.js';
-import { shellVersion } from './constants.js';
 
 import {WindowTilingSupport} from './windowTilingSupport.js';
 
@@ -383,7 +384,7 @@ export const MoveSession = class {
         }
 
         const savedMetaMaximized = window_state.meta_maximized;
-        if (shellVersion >= 49) {
+        if (Constants.shellVersion >= 49) {
             // Maximize a window to take up all of the space
             if (savedMetaMaximized) {
                 const currentMetaMaximized = metaWindow.is_maximized();
@@ -412,15 +413,21 @@ export const MoveSession = class {
         let delay = false;
         const window_state = saved_window_session.window_state;
         const savedMetaMaximized = window_state.meta_maximized;
-        if (shellVersion >= 49) {
+        if (Constants.shellVersion >= 49) {
             if (!savedMetaMaximized) {
                 // It can't be resized if current window is in maximum mode, including vertically maximization along the left and right sides of the screen
                 const currentMetaMaximized = metaWindow.is_maximized();
                 if (currentMetaMaximized) {
                     metaWindow.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
                     metaWindow.unmaximize();
-                    if (Meta.is_wayland_compositor() && !currentMetaMaximized) {
-                        delay = true;
+                    if (Constants.shellVersion >= 50) {
+                        if (!currentMetaMaximized) {
+                            delay = true;
+                        }
+                    } else {
+                        if (Meta.is_wayland_compositor() && !currentMetaMaximized) {
+                            delay = true;
+                        }
                     }
                 }
             }
@@ -430,8 +437,14 @@ export const MoveSession = class {
                 const currentMetaMaximized = metaWindow.get_maximized();
                 if (currentMetaMaximized) {
                     metaWindow.unmaximize(currentMetaMaximized);
-                    if (Meta.is_wayland_compositor() && currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
-                        delay = true;
+                    if (Constants.shellVersion >= 50) {
+                        if (currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
+                            delay = true;
+                        }
+                    } else {
+                        if (Meta.is_wayland_compositor() && currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
+                            delay = true;
+                        }
                     }
                 }
             }

--- a/prefs.js
+++ b/prefs.js
@@ -273,6 +273,9 @@ export default class AnotherWindowSessionManagerPreferences extends ExtensionPre
 
         this.close_by_rules_switch = this._builder.get_object('close_by_rules_switch');
         this.auto_close_session_switch = this._builder.get_object('auto_close_session_switch');
+
+        const versionLabel = this._builder.get_object('version_label');
+        versionLabel.set_label(`${this.metadata.version}`);
     }
 
     _installAutostartDesktopFile(desktopFileTemplate, targetDesktopFilePath) {

--- a/saveSession.js
+++ b/saveSession.js
@@ -280,6 +280,9 @@ export const SaveSession = class {
         window_position.width = frameRect.width;
         window_position.height = frameRect.height;
 
+        sessionConfigObject.window_hash = `${metaWindow.get_wm_class()}|${sessionConfigObject.desktop_number}|${frameRect.x}|${frameRect.y}`;
+        this._log.debug(`Window hash for ${appName} - ${metaWindow.get_title()}: ${sessionConfigObject.window_hash}`);
+
         let window_state = sessionConfigObject.window_state;
         // See: ui/windowMenu.js:L80
         window_state.is_sticky = metaWindow.is_on_all_workspaces();

--- a/saveSession.js
+++ b/saveSession.js
@@ -9,6 +9,8 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import * as SessionConfig from './model/sessionConfig.js';
 
+import * as Constants from './constants.js';
+
 import * as UiHelper from './ui/uiHelper.js';
 
 import * as FileUtils from './utils/fileUtils.js';
@@ -18,7 +20,6 @@ import * as CommonError from './utils/CommonError.js';
 import * as SubprocessUtils from './utils/subprocessUtils.js';
 import {PrefsUtils} from './utils/prefsUtils.js';
 import * as StringUtils from './utils/stringUtils.js';
-import { shellVersion } from './constants.js';
 
 
 export const SaveSession = class {
@@ -270,7 +271,11 @@ export const SaveSession = class {
         sessionConfigObject.windows_count = runningShellApp.get_n_windows();
         sessionConfigObject.fullscreen = metaWindow.is_fullscreen();
         sessionConfigObject.minimized = metaWindow.minimized;
-        sessionConfigObject.compositor_type = Meta.is_wayland_compositor() ? 'Wayland' : 'X11'
+        if (Constants.shellVersion >= 50) {
+            sessionConfigObject.compositor_type = 'Wayland'
+        } else {
+            sessionConfigObject.compositor_type = Meta.is_wayland_compositor() ? 'Wayland' : 'X11'
+        }
 
         const frameRect = metaWindow.get_frame_rect();
         let window_position = sessionConfigObject.window_position;
@@ -288,7 +293,7 @@ export const SaveSession = class {
         window_state.is_sticky = metaWindow.is_on_all_workspaces();
         window_state.is_above = metaWindow.is_above();
         
-        if (shellVersion >= 49) {
+        if (Constants.shellVersion >= 49) {
             window_state.meta_maximized = metaWindow.is_maximized();
         } else {
             window_state.meta_maximized = metaWindow.get_maximized();

--- a/scripts/dev_install.sh
+++ b/scripts/dev_install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Packing extension..."
+gnome-extensions pack --force --out-dir=. \
+    --extra-source=closeSession.js \
+    --extra-source=constants.js \
+    --extra-source=indicator.js \
+    --extra-source=moveSession.js \
+    --extra-source=openWindowsTracker.js \
+    --extra-source=prefsCloseWindow.js \
+    --extra-source=prefsColumnView.js \
+    --extra-source=prefsWidgets.js \
+    --extra-source=prefsWindowPickableEntry.js \
+    --extra-source=restoreSession.js \
+    --extra-source=saveSession.js \
+    --extra-source=windowTilingSupport.js \
+    --extra-source=dbus-interfaces \
+    --extra-source=icons \
+    --extra-source=model \
+    --extra-source=template \
+    --extra-source=ui \
+    --extra-source=utils
+
+echo "Installing..."
+gnome-extensions install --force ./another-window-session-manager@gmail.com.shell-extension.zip
+
+echo "Done. Run your nested session with:"
+echo "  dbus-run-session bash -c 'gsettings set org.gnome.shell enabled-extensions \"[\\\"another-window-session-manager@gmail.com\\\"]\" && gnome-shell --devkit --wayland'"

--- a/ui/prefs-gtk4.ui
+++ b/ui/prefs-gtk4.ui
@@ -933,5 +933,32 @@
         </child>
       </object>
     </child>
+    <child>
+      <object class="AdwPreferencesGroup" id="about_group">
+        <property name="title" translatable="yes">About</property>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">6</property>
+            <property name="margin-start">6</property>
+            <property name="margin-end">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="hexpand">true</property>
+                <property name="label" translatable="yes">Version</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="version_label">
+                <property name="halign">end</property>
+                <property name="label">-</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
   </object>
 </interface>

--- a/utils/metaWindowUtils.js
+++ b/utils/metaWindowUtils.js
@@ -2,16 +2,22 @@
 
 import Meta from 'gi://Meta';
 
+import * as Constants from '../constants.js';
+
 
 /**
  * Get the stable window id, don't change even after gnome shell is restarted
- * 
+ *
  * On X11, return xid; On Wayland, return id
- * 
+ *
  * @returns stable window id
  */
 export const getStableWindowId = function(metaWindow) {
-    return Meta.is_wayland_compositor() ? metaWindow.get_id() : metaWindow.get_description();
+    if (Constants.shellVersion >= 50) {
+        return metaWindow.get_id();
+    } else {
+        return Meta.is_wayland_compositor() ? metaWindow.get_id() : metaWindow.get_description();
+    }
 }
 
 export const isSurfaceActor = function(clutterActor) {


### PR DESCRIPTION
I've used this extension as my window-replacer and it has all the bells and whistles I need, except it didn't handle certain types of apps, such as firefox, or electron based apps (discord, tradingview).
These changes use a hash key that helps identify windows more uniquely, and it now moves them to their desktop, before moving them back in position. I also integrated the changes to adapt to Gnome 50.

Changes made with claude under my instructions and reviewed by me.