### PR TITLE
Add invisible window ID matching for reliable multi-window restore

### DIFF
--- a/moveSession.js
+++ b/moveSession.js
@@ -17,6 +17,33 @@ import { shellVersion } from './constants.js';
 import {WindowTilingSupport} from './windowTilingSupport.js';
 
 
+// Zero-width characters used by Window Titler's invisible ID feature.
+// Each window gets a unique 4-char prefix encoded in these characters.
+const ZERO_WIDTH_CHARS = new Set([
+    '\u200B', // Zero Width Space
+    '\u200C', // Zero Width Non-Joiner
+    '\u200D', // Zero Width Joiner
+    '\u2060', // Word Joiner
+]);
+const INVISIBLE_ID_LENGTH = 4;
+
+// Extract the invisible ID prefix from a window title, or null if none.
+function _extractInvisibleId(title) {
+    if (!title || title.length < INVISIBLE_ID_LENGTH) return null;
+    for (let i = 0; i < INVISIBLE_ID_LENGTH; i++) {
+        if (!ZERO_WIDTH_CHARS.has(title[i])) return null;
+    }
+    return title.substring(0, INVISIBLE_ID_LENGTH);
+}
+
+// Match two window titles by their invisible ID prefix (if both have one).
+// Returns true if both titles have an invisible ID and they are identical.
+function _matchByInvisibleId(titleA, titleB) {
+    const idA = _extractInvisibleId(titleA);
+    const idB = _extractInvisibleId(titleB);
+    return idA !== null && idB !== null && idA === idB;
+}
+
 export const MoveSession = class {
 
     constructor() {
@@ -277,7 +304,11 @@ export const MoveSession = class {
             const open_window_workspace_index = metaWindow.get_workspace().index();
             const desktop_number = saved_window_session.desktop_number;
 
-            if (windows_count === 1 || title === saved_window_session.window_title) {
+            const invisibleMatch = _matchByInvisibleId(title, saved_window_session.window_title);
+            const titleExactMatch = title === saved_window_session.window_title;
+            const singleWindow = windows_count === 1;
+
+            if (singleWindow || invisibleMatch || titleExactMatch) {
                 if (open_window_workspace_index === desktop_number) {
                     if (this._log.isDebug()) {
                         const shellApp = this._windowTracker.get_window_app(metaWindow);
@@ -457,7 +488,11 @@ export const MoveSession = class {
                 const open_window_workspace_index = open_window.get_workspace().index();
                 const desktop_number = saved_window_session.desktop_number;
 
-                if (windows_count === 1 || title === saved_window_session.window_title) {
+                const invisibleMatch = _matchByInvisibleId(title, saved_window_session.window_title);
+                const titleExactMatch = title === saved_window_session.window_title;
+                const singleWindow = windows_count === 1;
+
+                if (singleWindow || invisibleMatch || titleExactMatch) {
                     if (open_window_workspace_index === desktop_number) {
                         this._log.debug(`The window '${title}' is already on workspace ${desktop_number} for ${shellApp.get_name()}`);
                         this._restoreWindowStates(open_window, saved_window_session, true);


### PR DESCRIPTION
## Summary

When restoring a session, AWSM currently matches windows by exact title or single-window heuristic. This works well for most apps but fails for browsers like Firefox when page titles change between save and restore.

This PR adds support for **invisible window ID matching** using zero-width Unicode characters (U+200B, U+200C, U+200D, U+2060) that can be embedded as a 4-character prefix in window titles by browser addons like [Window Titler](https://addons.mozilla.org/firefox/addon/window-titler/). Each window gets a unique, persistent invisible ID that survives page navigation.

### How it works

- A `_extractInvisibleId(title)` function checks if a window title starts with 4 zero-width characters and extracts them as an ID
- A `_matchByInvisibleId(titleA, titleB)` function compares two titles by their invisible ID prefix
- The matching is added in both `_getOneMatchedSavedWindow()` and `_autoMoveWindows()`, with priority: `singleWindow > invisibleId > exactTitle`
- If no invisible ID is present, matching falls back to the existing behavior — fully backward compatible

### Example

A Firefox window titled `​​​‌Twake Chat — Mozilla Firefox` (with invisible ID 1 prefix) is saved. After restart, the same window shows `​​​‌Twake Calendar — Mozilla Firefox` (different page, same invisible ID 1). AWSM matches them correctly and restores the window to its saved workspace.

## Test plan

- [x] Tested with 3 Firefox windows on different workspaces, each with a unique invisible ID
- [x] Saved session, changed page titles, restored — all windows matched by invisible ID
- [x] Verified non-Firefox windows (VS Code, Ghostty) still match by existing methods
- [x] Verified backward compatibility: windows without invisible IDs match as before