### PR TITLE
Correcting typos in "Running applications" error message

### DIFF
--- a/closeSession.js
+++ b/closeSession.js
@@ -157,7 +157,7 @@ export const CloseSession = class {
                         }
                     } else {
                         closed = false;
-                        reason = 'it has multiple normal windows and does not in the whitelist';
+                        reason = 'it has multiple normal windows and is not on the whitelist';
                     }
                 }
             }

--- a/ui/autoclose.js
+++ b/ui/autoclose.js
@@ -193,7 +193,7 @@ export const Autoclose = GObject.registerClass(
                                 const { hasRunningApps } = result;
                                 if (hasRunningApps) {
                                     that._log.debug('One or more apps cannot be closed, please close them manually.');
-                                    that._runningApplicationListWindow._applicationSection.title = `Those apps can't be closed, please close them manually`;
+                                    that._runningApplicationListWindow._applicationSection.title = `These apps can't be closed, please close them manually`;
                                     that._runningApplicationListWindow.showRunningApps();
                                     that._runningApplicationListWindow._retryButton.reactive = true;
                                 } else {


### PR DESCRIPTION
# Issue
When attempting to close an application with multiple windows (v51 of this extension on Ubuntu 24.04.4 LTS), the following "Running applications" dialog is displayed. It contains typos in two sentences, raising this pull request to propose fixes for them.

<img width="1024" height="560" alt="Screenshot from 2026-03-30 20-39-20" src="https://github.com/user-attachments/assets/76c86a24-fa57-4c66-a6d0-3e666c97a247" />

# Proposed fixes
Changing 
- "Those apps can't be closed, please close them manually"
to
- "These apps can't be closed, please close them manually"

and
- "It has multiple normal windows and does not in the whitelist"
to
- "It has multiple normal windows and is not on the whitelist"

# Other issues
I also noticed other phrasing issues within the `autoclose.js` and `closeSession.js`, but wanted to limit the scope of this pull request. I recommend further phrasing checks, and I can raise future PRs if needed.