### PR TITLE
Add GNOME 50 compatibility support

### DIFF
--- a/closeSession.js
+++ b/closeSession.js
@@ -486,7 +486,7 @@ export const CloseSession = class {
         }
 
         let windows;
-        if (Meta.is_wayland_compositor()) {
+        if (Meta.is_wayland_compositor) {
             windows = this._sortWindowsOnWayland(app);
         } else {
             windows = this._sortWindowsOnX11(app);

--- a/indicator.js
+++ b/indicator.js
@@ -80,7 +80,7 @@ class AwsIndicator extends PanelMenu.Button {
 
     // TODO Move this method and related code to a single .js file
     async _windowCreated(display, metaWindow, userData) {
-        if (!Meta.is_wayland_compositor()) {
+        if (!Meta.is_wayland_compositor) {
             // We call createEnoughWorkspaceAndMoveWindows() if and only if all conditions checked.
             
             // But we give some windows (such as the OS running in VirtualBox) a chance to connect `first-frame` and `shown` signals.

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
       "46",
       "47",
       "48",
-      "49"
+      "49",
+      "50"
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",

--- a/moveSession.js
+++ b/moveSession.js
@@ -369,7 +369,7 @@ export const MoveSession = class {
                 if (currentMetaMaximized) {
                     metaWindow.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
                     metaWindow.unmaximize();
-                    if (Meta.is_wayland_compositor() && !currentMetaMaximized) {
+                    if (Meta.is_wayland_compositor && !currentMetaMaximized) {
                         delay = true;
                     }
                 }
@@ -380,7 +380,7 @@ export const MoveSession = class {
                 const currentMetaMaximized = metaWindow.get_maximized();
                 if (currentMetaMaximized) {
                     metaWindow.unmaximize(currentMetaMaximized);
-                    if (Meta.is_wayland_compositor() && currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
+                    if (Meta.is_wayland_compositor && currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
                         delay = true;
                     }
                 }

--- a/saveSession.js
+++ b/saveSession.js
@@ -270,7 +270,7 @@ export const SaveSession = class {
         sessionConfigObject.windows_count = runningShellApp.get_n_windows();
         sessionConfigObject.fullscreen = metaWindow.is_fullscreen();
         sessionConfigObject.minimized = metaWindow.minimized;
-        sessionConfigObject.compositor_type = Meta.is_wayland_compositor() ? 'Wayland' : 'X11'
+        sessionConfigObject.compositor_type = Meta.is_wayland_compositor ? 'Wayland' : 'X11'
 
         const frameRect = metaWindow.get_frame_rect();
         let window_position = sessionConfigObject.window_position;

--- a/utils/metaWindowUtils.js
+++ b/utils/metaWindowUtils.js
@@ -11,7 +11,7 @@ import Meta from 'gi://Meta';
  * @returns stable window id
  */
 export const getStableWindowId = function(metaWindow) {
-    return Meta.is_wayland_compositor() ? metaWindow.get_id() : metaWindow.get_description();
+    return Meta.is_wayland_compositor ? metaWindow.get_id() : metaWindow.get_description();
 }
 
 export const isSurfaceActor = function(clutterActor) {


### PR DESCRIPTION
GNOME 50 changed Meta.is_wayland_compositor() from a function call to a property. This patch updates all usages accordingly and adds GNOME 50 compatibility support in metadata.json.

Note: Tested successfully on Fedora Workstation 44 with GNOME Shell 50.1.