### PR TITLE
Updated for GNOME 50

### DIFF
--- a/closeSession.js
+++ b/closeSession.js
@@ -487,7 +487,7 @@ export const CloseSession = class {
 
         let windows;
 
-        if (shellVersion >= 50) {
+        if (Constants.shellVersion >= 50) {
             windows = this._sortWindowsOnWayland(app);
         } else {
             if (Meta.is_wayland_compositor()) {

--- a/closeSession.js
+++ b/closeSession.js
@@ -486,10 +486,15 @@ export const CloseSession = class {
         }
 
         let windows;
-        if (Meta.is_wayland_compositor()) {
+
+        if (shellVersion >= 50) {
             windows = this._sortWindowsOnWayland(app);
         } else {
-            windows = this._sortWindowsOnX11(app);
+            if (Meta.is_wayland_compositor()) {
+                windows = this._sortWindowsOnWayland(app);
+            } else {
+                windows = this._sortWindowsOnX11(app);
+            }
         }
         return windows;
     }

--- a/indicator.js
+++ b/indicator.js
@@ -80,50 +80,52 @@ class AwsIndicator extends PanelMenu.Button {
 
     // TODO Move this method and related code to a single .js file
     async _windowCreated(display, metaWindow, userData) {
-        if (!Meta.is_wayland_compositor()) {
-            // We call createEnoughWorkspaceAndMoveWindows() if and only if all conditions checked.
-            
-            // But we give some windows (such as the OS running in VirtualBox) a chance to connect `first-frame` and `shown` signals.
-            // The reason I do this is that 
-            // `Shell.AppSystem.get_default().lookup_app('a-VirtualBox-machine-name.desktop')`
-            // and `Shell.WindowTracker.get_default().get_window_app(metaWindow_of_VirtualBoxMachine)`
-            // are not the same instance. 
-            
-            // My best guess is:
-            // Looks like if launch a VirtualBox machine via `/usr/lib64/virtualbox/VirtualBoxVM --comment "test" --startvm "{xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxxxxxxxxx}"`,
-            // it will open two process: the first process open another process, which is running a machine, and then the first process stops to run and the associated Shell.App is also destroyed.
-            // And
-            // the two processes all have window, window of the first process will be destroyed before/after the second process open a new window, which is running the virtual OS.
-            // Install https://extensions.gnome.org/extension/4679/burn-my-windows/ to watch this process.
-
-            const shellApp = this._windowTracker.get_window_app(metaWindow);
-            let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
-            if (!shellAppData) {
-                shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
-            }
-
-            if (shellAppData) {
-                const saved_window_sessions = shellAppData.saved_window_sessions;
-
-                // On X11, we have to create enough workspace and move windows before receive the first-frame signal.
-                // If not, all windows will be shown in current workspace when stay in Overview, which is not pretty.
-                let matchedSavedWindowSession = await this._moveSession.createEnoughWorkspaceAndMoveWindows(metaWindow, saved_window_sessions);
+        if (shellVersion < 50) {
+            if (!Meta.is_wayland_compositor()) {
+                // We call createEnoughWorkspaceAndMoveWindows() if and only if all conditions checked.
                 
-                if (matchedSavedWindowSession) {
-                    // We try to restore window state here if necessary.
-                    // Below are possible reasons:
-                    // 1) In current implement there is no guarantee that the first-frame and shown signals can be triggered immediately. You have to click a window to trigger them.
-                    // 2) The restored window state could be lost
-                    this._log.debug(`Restoring window state of ${shellApp.get_name()} - ${metaWindow.get_title()} if necessary`);
-                    this._moveSession._restoreWindowState(metaWindow, matchedSavedWindowSession);
+                // But we give some windows (such as the OS running in VirtualBox) a chance to connect `first-frame` and `shown` signals.
+                // The reason I do this is that 
+                // `Shell.AppSystem.get_default().lookup_app('a-VirtualBox-machine-name.desktop')`
+                // and `Shell.WindowTracker.get_default().get_window_app(metaWindow_of_VirtualBoxMachine)`
+                // are not the same instance. 
+                
+                // My best guess is:
+                // Looks like if launch a VirtualBox machine via `/usr/lib64/virtualbox/VirtualBoxVM --comment "test" --startvm "{xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxx-xxxxxxxxxxxxxx}"`,
+                // it will open two process: the first process open another process, which is running a machine, and then the first process stops to run and the associated Shell.App is also destroyed.
+                // And
+                // the two processes all have window, window of the first process will be destroyed before/after the second process open a new window, which is running the virtual OS.
+                // Install https://extensions.gnome.org/extension/4679/burn-my-windows/ to watch this process.
 
-
-                    // Fix window geometry later on in first-frame signal
-                    // TODO The side-effect is when a window is already in the current workspace there will be two same logs (The window 'Clocks' is already on workspace 0 for Clocks) in the journalctl, which is not pretty.
-                    // TODO Maybe it's better to use another state to indicator whether a window has been restored geometry.
-                    matchedSavedWindowSession.moved = false;
+                const shellApp = this._windowTracker.get_window_app(metaWindow);
+                let shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(shellApp);
+                if (!shellAppData) {
+                    shellAppData = RestoreSession.restoreSessionObject.restoringApps.get(metaWindow.get_pid());
                 }
-            }
+
+                if (shellAppData) {
+                    const saved_window_sessions = shellAppData.saved_window_sessions;
+
+                    // On X11, we have to create enough workspace and move windows before receive the first-frame signal.
+                    // If not, all windows will be shown in current workspace when stay in Overview, which is not pretty.
+                    let matchedSavedWindowSession = await this._moveSession.createEnoughWorkspaceAndMoveWindows(metaWindow, saved_window_sessions);
+                    
+                    if (matchedSavedWindowSession) {
+                        // We try to restore window state here if necessary.
+                        // Below are possible reasons:
+                        // 1) In current implement there is no guarantee that the first-frame and shown signals can be triggered immediately. You have to click a window to trigger them.
+                        // 2) The restored window state could be lost
+                        this._log.debug(`Restoring window state of ${shellApp.get_name()} - ${metaWindow.get_title()} if necessary`);
+                        this._moveSession._restoreWindowState(metaWindow, matchedSavedWindowSession);
+
+
+                        // Fix window geometry later on in first-frame signal
+                        // TODO The side-effect is when a window is already in the current workspace there will be two same logs (The window 'Clocks' is already on workspace 0 for Clocks) in the journalctl, which is not pretty.
+                        // TODO Maybe it's better to use another state to indicator whether a window has been restored geometry.
+                        matchedSavedWindowSession.moved = false;
+                    }
+                }
+            }   
         }
         
         let metaWindowActor = metaWindow.get_compositor_private();

--- a/indicator.js
+++ b/indicator.js
@@ -80,7 +80,7 @@ class AwsIndicator extends PanelMenu.Button {
 
     // TODO Move this method and related code to a single .js file
     async _windowCreated(display, metaWindow, userData) {
-        if (shellVersion < 50) {
+        if (Constants.shellVersion < 50) {
             if (!Meta.is_wayland_compositor()) {
                 // We call createEnoughWorkspaceAndMoveWindows() if and only if all conditions checked.
                 

--- a/metadata.json
+++ b/metadata.json
@@ -7,9 +7,10 @@
       "46",
       "47",
       "48",
-      "49"
+      "49",
+      "50"
     ],
     "url": "https://github.com/nlpsuge/gnome-shell-extension-another-window-session-manager",
     "uuid": "another-window-session-manager@gmail.com",
-    "version": 53
+    "version": 54
   }

--- a/moveSession.js
+++ b/moveSession.js
@@ -369,8 +369,14 @@ export const MoveSession = class {
                 if (currentMetaMaximized) {
                     metaWindow.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
                     metaWindow.unmaximize();
-                    if (Meta.is_wayland_compositor() && !currentMetaMaximized) {
-                        delay = true;
+                    if (shellVersion >= 50) {
+                        if (!currentMetaMaximized) {
+                            delay = true;
+                        }            
+                    } else {
+                        if (Meta.is_wayland_compositor() && !currentMetaMaximized) {
+                            delay = true;
+                        }
                     }
                 }
             }
@@ -380,8 +386,14 @@ export const MoveSession = class {
                 const currentMetaMaximized = metaWindow.get_maximized();
                 if (currentMetaMaximized) {
                     metaWindow.unmaximize(currentMetaMaximized);
-                    if (Meta.is_wayland_compositor() && currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
-                        delay = true;
+                    if (shellVersion >= 50) {
+                        if (currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
+                            delay = true;
+                        }                        
+                    } else {
+                        if (Meta.is_wayland_compositor() && currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
+                            delay = true;
+                        }
                     }
                 }
             }

--- a/moveSession.js
+++ b/moveSession.js
@@ -7,12 +7,13 @@ import Meta from 'gi://Meta';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
+import * as Constants from './constants.js';
+
 import * as UiHelper from './ui/uiHelper.js';
 
 import * as FileUtils from './utils/fileUtils.js';
 import * as Log from './utils/log.js';
 import * as DateUtils from './utils/dateUtils.js';
-import { shellVersion } from './constants.js';
 
 import {WindowTilingSupport} from './windowTilingSupport.js';
 
@@ -333,7 +334,7 @@ export const MoveSession = class {
         }
 
         const savedMetaMaximized = window_state.meta_maximized;
-        if (shellVersion >= 49) {
+        if (Constants.shellVersion >= 49) {
             // Maximize a window to take up all of the space
             if (savedMetaMaximized) {
                 const currentMetaMaximized = metaWindow.is_maximized();
@@ -362,14 +363,14 @@ export const MoveSession = class {
         let delay = false;
         const window_state = saved_window_session.window_state;
         const savedMetaMaximized = window_state.meta_maximized;
-        if (shellVersion >= 49) {
+        if (Constants.shellVersion >= 49) {
             if (!savedMetaMaximized) {
                 // It can't be resized if current window is in maximum mode, including vertically maximization along the left and right sides of the screen
                 const currentMetaMaximized = metaWindow.is_maximized();
                 if (currentMetaMaximized) {
                     metaWindow.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
                     metaWindow.unmaximize();
-                    if (shellVersion >= 50) {
+                    if (Constants.shellVersion >= 50) {
                         if (!currentMetaMaximized) {
                             delay = true;
                         }            
@@ -386,7 +387,7 @@ export const MoveSession = class {
                 const currentMetaMaximized = metaWindow.get_maximized();
                 if (currentMetaMaximized) {
                     metaWindow.unmaximize(currentMetaMaximized);
-                    if (shellVersion >= 50) {
+                    if (Constants.shellVersion >= 50) {
                         if (currentMetaMaximized !== Meta.MaximizeFlags.BOTH) {
                             delay = true;
                         }                        

--- a/saveSession.js
+++ b/saveSession.js
@@ -9,6 +9,8 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import * as SessionConfig from './model/sessionConfig.js';
 
+import * as Constants from './constants.js';
+
 import * as UiHelper from './ui/uiHelper.js';
 
 import * as FileUtils from './utils/fileUtils.js';
@@ -18,7 +20,6 @@ import * as CommonError from './utils/CommonError.js';
 import * as SubprocessUtils from './utils/subprocessUtils.js';
 import {PrefsUtils} from './utils/prefsUtils.js';
 import * as StringUtils from './utils/stringUtils.js';
-import { shellVersion } from './constants.js';
 
 
 export const SaveSession = class {
@@ -271,7 +272,7 @@ export const SaveSession = class {
         sessionConfigObject.fullscreen = metaWindow.is_fullscreen();
         sessionConfigObject.minimized = metaWindow.minimized;
 
-        if (shellVersion >= 50) {
+        if (Constants.shellVersion >= 50) {
             sessionConfigObject.compositor_type = 'Wayland'
         } else {
             sessionConfigObject.compositor_type = Meta.is_wayland_compositor() ? 'Wayland' : 'X11'
@@ -290,7 +291,7 @@ export const SaveSession = class {
         window_state.is_sticky = metaWindow.is_on_all_workspaces();
         window_state.is_above = metaWindow.is_above();
         
-        if (shellVersion >= 49) {
+        if (Constants.shellVersion >= 49) {
             window_state.meta_maximized = metaWindow.is_maximized();
         } else {
             window_state.meta_maximized = metaWindow.get_maximized();

--- a/saveSession.js
+++ b/saveSession.js
@@ -270,7 +270,12 @@ export const SaveSession = class {
         sessionConfigObject.windows_count = runningShellApp.get_n_windows();
         sessionConfigObject.fullscreen = metaWindow.is_fullscreen();
         sessionConfigObject.minimized = metaWindow.minimized;
-        sessionConfigObject.compositor_type = Meta.is_wayland_compositor() ? 'Wayland' : 'X11'
+
+        if (shellVersion >= 50) {
+            sessionConfigObject.compositor_type = 'Wayland'
+        } else {
+            sessionConfigObject.compositor_type = Meta.is_wayland_compositor() ? 'Wayland' : 'X11'
+        }
 
         const frameRect = metaWindow.get_frame_rect();
         let window_position = sessionConfigObject.window_position;

--- a/utils/metaWindowUtils.js
+++ b/utils/metaWindowUtils.js
@@ -11,7 +11,11 @@ import Meta from 'gi://Meta';
  * @returns stable window id
  */
 export const getStableWindowId = function(metaWindow) {
-    return Meta.is_wayland_compositor() ? metaWindow.get_id() : metaWindow.get_description();
+    if (shellVersion >= 50) {
+        return metaWindow.get_id();
+    } else {
+        return Meta.is_wayland_compositor() ? metaWindow.get_id() : metaWindow.get_description();
+    }
 }
 
 export const isSurfaceActor = function(clutterActor) {

--- a/utils/metaWindowUtils.js
+++ b/utils/metaWindowUtils.js
@@ -2,6 +2,8 @@
 
 import Meta from 'gi://Meta';
 
+import * as Constants from '../constants.js';
+
 
 /**
  * Get the stable window id, don't change even after gnome shell is restarted
@@ -11,7 +13,7 @@ import Meta from 'gi://Meta';
  * @returns stable window id
  */
 export const getStableWindowId = function(metaWindow) {
-    if (shellVersion >= 50) {
+    if (Constants.shellVersion >= 50) {
         return metaWindow.get_id();
     } else {
         return Meta.is_wayland_compositor() ? metaWindow.get_id() : metaWindow.get_description();


### PR DESCRIPTION
Since GNOME 50 is dropping X11 rendering backend, Meta.is_wayland_compositor() is no longer supported.
This PR removes those calls for versions >= 50 and still uses the old code path for versions < 50.
Updated Metadata for version 50.